### PR TITLE
Changed TextView.getTag method to return value of tag variable

### DIFF
--- a/src/ui/backend/canvas/TextView.js
+++ b/src/ui/backend/canvas/TextView.js
@@ -357,7 +357,7 @@ var TextView = exports = Class(View, function(supr) {
 	};
 
 	this.getTag = function() {
-		return "TextView" + this.uid + ":" + (this._lines && this._lines.join(" ").substring(0, 20));
+		return "TextView" + this.uid + ":" + this.tag;
 	};
 
 	this.reflow = function () {


### PR DESCRIPTION
This pull requests should fix [this issue](https://github.com/gameclosure/devkit/issues/32). UI inspector will now display tag property for _TextView_ objects
