### PR TITLE
Same initialization path for all View instances

### DIFF
--- a/src/ui/ViewPool.js
+++ b/src/ui/ViewPool.js
@@ -83,7 +83,7 @@ exports = Class(function () {
 			}
 
 			// create a new view
-			view = new this.ctor(opts);
+			view = new this.ctor(viewOpts);
 			view._poolIndex = this.views.length;
 			this.views.push(view);
 		}


### PR DESCRIPTION
Currently, ViewPool instances generated for the original pool are initialized using `initOpts`.

Views recycled from the pool retain these settings, but when the pool is exhausted, new instances are generated without the `initOpts` and only use the options provided directly to `obtainView`.

This change retains a reference to the ViewPool's original `initOpts` and re-uses these options when instantiating new Views for the exhausted pool. Additionally, options provided to `obtainView` are always passed to the view through `updateOpts`, regardless of whether the View already existed in the pool or was newly-instantiated.
