### PR TITLE
SpriteView callback receives instance as argument

### DIFF
--- a/src/ui/SpriteView.js
+++ b/src/ui/SpriteView.js
@@ -283,7 +283,7 @@ var SpriteView = exports = Class("SpriteView", ImageView, function (logger, supr
 				this._callback = null;
 
 				this.resetAnimation();
-				if (cb) cb();
+				if (cb) cb(this);
 			}
 		}
 	};


### PR DESCRIPTION
This is useful when SpriteViews are used in a ViewPool, allowing a single closure to service all View instances, reducing allocations and GC churn.
