### PR TITLE
Translate 3D Support for DOM

### DIFF
--- a/src/ui/backend/dom/ViewBacking.js
+++ b/src/ui/backend/dom/ViewBacking.js
@@ -276,7 +276,7 @@ var ViewBacking = exports = Class(BaseBacking, function () {
 			var translate = 'translate3d(' + (x) + 'px,' + (y) + 'px,0)';
 
 			// Check for differences and other properties like scale, rotate, translate, etc
-			if (s[TRANSFORM_PREFIX] != '' && s[trans] != translate) {
+			if (s[TRANSFORM_PREFIX] != '' && s[TRANSFORM_PREFIX] != translate) {
 				s[TRANSFORM_PREFIX] += translate;
 			}
 			else {


### PR DESCRIPTION
Adds translate3d support to the DOM backing view. This should give desktop builds slightly better performance.

Adds a :position(x, y) method to abstract "top/left" vs "translate3d(x,y)".

Adds a :CHECK_TRANSLATE3D method to check for support and detect correct prefix.

Falls back to top/left if it cannot be done. This means IE10, FF16+, Chrome 20+ and Safari 5+ all now support translate3d.
