### PR TITLE
Set default size to 0

### DIFF
--- a/src/ui/backend/canvas/TextFlow.js
+++ b/src/ui/backend/canvas/TextFlow.js
@@ -44,7 +44,7 @@ var TextFlow = exports = Class(PubSub, function (supr) {
 		this._maxWidth = 0;
 		this._maxHeight = 0;
 
-		this._heightFound = -1;
+		this._heightFound = 0;
 
 		this._offsetRect = {x: 0, y: 0, width: 0, height: 0};
 	};


### PR DESCRIPTION
Setting default size to 0. Previously this used to cause a font undefined js error for ButtonViews that don't have TextViews in them.
