### PR TITLE
method to detect tablet

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -104,8 +104,10 @@ if (exports.isMobile) {
 	exports.width = navigator.width;
 	exports.height = navigator.height;
 	exports.isAndroid = /Android/.test(ua);
-	if (!exports.isAndroid) {
-		exports.isIPad = /iPad/.test(ua);
+	if (exports.isAndroid) {
+		exports.isTablet = navigator.width/devicePixelRatio >= 600;
+	} else {
+		exports.isIPad = exports.isTablet = /iPad/.test(ua);
 		exports.isIPhone = /iPhone/.test(ua);
 
 		// Until we support more platforms, if it's not


### PR DESCRIPTION
In this commit density dp is used to identify tablet.
Considering anything equal and above 600dp as tablet.
http://developer.android.com/guide/practices/screens_support.html#ConfigurationExamples
