### PR TITLE
forEachActiveView allows view release during iteration

### DIFF
--- a/src/ui/ViewPool.js
+++ b/src/ui/ViewPool.js
@@ -115,7 +115,7 @@ exports = Class(function () {
 	this.forEachActiveView = function(fn, ctx) {
 		var views = this._views;
 		var f = bind(ctx, fn);
-		for (var i = 0, len = this._freshViewIndex; i < len; i++) {
+		for (var i = this._freshViewIndex - 1; i >= 0; i--) {
 			f(views[i], i);
 		}
 	};


### PR DESCRIPTION
It's very important to be able to release views while you're iterating over the active collection. By decrementing from the freshViewIndex down to 0, it's now safe to do so using the ViewPool's forEachActiveView function.
