### PR TITLE
fix typo of default value in keyboard type

### DIFF
--- a/src/platforms/native/InputPrompt.js
+++ b/src/platforms/native/InputPrompt.js
@@ -60,7 +60,7 @@ exports = Class(function () {
 		if (typeof opts.keyboardType === 'string') {
 			opts.keyboardType = KeyboardTypes[opts.keyboardType];
 		}
-		this._keyboardType = opts.keyboardType !== undefined ? opts.keyboardType : KeyboardTypes.default;
+		this._keyboardType = opts.keyboardType !== undefined ? opts.keyboardType : KeyboardTypes.Default;
 		this._id = -1;
 	};
 


### PR DESCRIPTION
The default value for Keyboard type is wrongly mapped.