### PR TITLE
removing global assignment of gridView

### DIFF
--- a/src/ui/widget/GridView.js
+++ b/src/ui/widget/GridView.js
@@ -20,7 +20,7 @@ import ui.View as View;
  * @class ui.widget.GridView
  * @docsrc https://github.com/gameclosure/doc/blob/master/api/ui/widget/gridview.md
  */
-exports = GridView = Class(View, function (supr) {
+exports = Class(View, function (supr) {
 	this.init = function (opts) {
 		opts = merge(opts, {
 			horizontalMargin: 0,


### PR DESCRIPTION
Since `var` is missing, importing gridview sets a global variable.
And variable is not used anywhere else, so removing it.