### PR TITLE
adding back centerAnchor

### DIFF
--- a/src/ui/layout/BoxLayout.js
+++ b/src/ui/layout/BoxLayout.js
@@ -150,6 +150,10 @@ var BoxLayout = exports = Class(function () {
 		// Note that we don't trigger any resize handlers here
 		s._width = w;
 
+		if (s.centerAnchor) {
+			s.anchorX = w / 2;
+		}
+
 		if (!inLinearLayout && svWidth) {
 			if (w !== undefined && s.centerX) { s.x = Math.round((availWidth - s.scale * w) / 2 + (padding && padding.left || 0)); }
 			if (w !== undefined && s.left == undefined && s.right != undefined) { s.x = Math.round(availWidth - s.scale * w - s.right - (padding && padding.right || 0)); }
@@ -186,6 +190,10 @@ var BoxLayout = exports = Class(function () {
 		}
 
 		s._height = h;
+
+		if (s.centerAnchor) {
+			s.anchorY = h / 2;
+		}
 
 		if (!inLinearLayout && svHeight) {
 			if (h !== undefined && s.centerY) { s.y = Math.round((availHeight - s.scale * h) / 2 + (padding && padding.top || 0)); }


### PR DESCRIPTION
centerAnchor supposed to recenter the view on dimension change. It got removed in the timestep for devkit2.