### PR TITLE
Remove 100Hz setTimeout loop

### DIFF
--- a/src/AudioManager.js
+++ b/src/AudioManager.js
@@ -257,7 +257,7 @@ var MultiSound = Class(function () {
 			if (this._lastSrc.duration) {
 				this._lastSrc.currentTime = t;
 			} else {
-				setTimeout(bind(this, 'setTime', t + 0.01), 10);
+				//setTimeout(bind(this, 'setTime', t + 0.01), 10);
 			}
 		}
 	};


### PR DESCRIPTION
Not sure what this thing accomplished other than adding a 60Hz timer loop (the code says 100Hz, but ticks are only every 17ms). I have been making builds with this for a while and not having any issues.