### PR TITLE
new animation groups / caching paradigm

### DIFF
--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -857,3 +857,28 @@ View.setDefaultViewBacking = function (ViewBackingCtor) {
 
 // default view backing is canvas
 View.setDefaultViewBacking(backend.canvas.ViewBacking);
+
+// traverse the view hierarchy to find a specific view by its uid
+View.findViewByID = function (id) {
+	var root = GC.app && GC.app.view;
+	if (root) {
+		return findViewByID(root, id);
+	} else {
+		return null;
+	}
+};
+
+function findViewByID (view, id) {
+	if (view.uid === id) {
+		return view;
+	}
+	var subviews = view.getSubviews();
+	for (var i = 0; i < subviews.length; i++) {
+		var sub = subviews[i];
+		var res = findViewByID(sub, id);
+		if (res) {
+			return res;
+		}
+	}
+	return null;
+};

--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -857,28 +857,3 @@ View.setDefaultViewBacking = function (ViewBackingCtor) {
 
 // default view backing is canvas
 View.setDefaultViewBacking(backend.canvas.ViewBacking);
-
-// traverse the view hierarchy to find a specific view by its uid
-View.findViewByID = function (id) {
-	var root = GC.app && GC.app.view;
-	if (root) {
-		return findViewByID(root, id);
-	} else {
-		return null;
-	}
-};
-
-function findViewByID (view, id) {
-	if (view.uid === id) {
-		return view;
-	}
-	var subviews = view.getSubviews();
-	for (var i = 0; i < subviews.length; i++) {
-		var sub = subviews[i];
-		var res = findViewByID(sub, id);
-		if (res) {
-			return res;
-		}
-	}
-	return null;
-};

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -187,8 +187,7 @@ var Group = Class(Emitter, function () {
 
 // returns a new Group containing a set of Animators w the same animID
 exports.getGroup = function (animID) {
-	animID = animID || DEFAULT_ANIM_ID;
-	return new Group(animID);
+	return new Group(animID || DEFAULT_ANIM_ID);
 };
 
 var TRANSITIONS = [

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -51,6 +51,49 @@ exports = function (subject, animID) {
 	return anim;
 };
 
+// get all animations on a given subject
+exports.getSubjectAnimations = function (subject) {
+	var anims = subject.__anims || {};
+	var animsArray = [];
+	for (var id in anims) {
+		animsArray.push(anims[id]);
+	}
+	return animsArray;
+};
+
+// clear all animations on a given subject
+exports.clearSubjectAnimations = function (subject) {
+	var anims = this.getSubjectAnimations(subject);
+	for (var i = 0; i < anims.length; i++) {
+		anims[i].clear();
+	}
+};
+
+// commit all animations on a given subject
+exports.commitSubjectAnimations = function (subject) {
+	var anims = this.getSubjectAnimations(subject);
+	for (var i = 0; i < anims.length; i++) {
+		anims[i].commit();
+	}
+};
+
+// pause all animations on a given subject
+exports.pauseSubjectAnimations = function (subject) {
+	var anims = this.getSubjectAnimations(subject);
+	for (var i = 0; i < anims.length; i++) {
+		anims[i].pause();
+	}
+};
+
+// resume all animations on a given subject
+exports.resumeSubjectAnimations = function (subject) {
+	var anims = this.getSubjectAnimations(subject);
+	for (var i = 0; i < anims.length; i++) {
+		anims[i].resume();
+	}
+};
+
+// used to get/set native or browser ViewAnimator constructors
 exports.getViewAnimator = function () {
 	return ViewAnimator;
 };

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -24,10 +24,9 @@ import event.Emitter as Emitter;
 import animate.transitions as transitions;
 import timer;
 
-var anim_uid = 0;
+var uid = 0;
 
-exports = function (subject, groupId) {
-
+exports = function (subject, groupID) {
 	// TODO: we have a circular import, so do the Engine import on first use
 	if (typeof Engine == 'undefined') {
 		import ui.Engine as Engine;
@@ -35,25 +34,24 @@ exports = function (subject, groupId) {
 		import device;
 	}
 
-	if (device.useDOM && subject instanceof View && !groupId) {
+	if (device.useDOM && subject instanceof View && !groupID) {
 		return subject.getAnimation();
 	}
 
-	var groupId = groupId || 0,
-		group = groups[groupId] || (groups[groupId] = new Group()),
-		animID = subject.__anim_id || (subject.__anim_id = '__anim_' + (++anim_uid)),
-		anim = group.get(animID);
-
+	var groupID = groupID || 0;
+	var animID = subject.__anim_id || (subject.__anim_id = '__anim_' + (++uid));
+	var anims = subject.__anims || (subject.__anims = {});
+	var group = anims[groupID] || (anims[groupID] = new Group());
+	var anim = group.get(animID);
 	if (!anim) {
 		anim = subject instanceof View
-				? new ViewAnimator(subject, group)
-				: new Animator(subject, group);
-
+			? new ViewAnimator(subject, group)
+			: new Animator(subject, group);
 		group.add(animID, anim);
 	}
 
 	return anim;
-}
+};
 
 exports.getViewAnimator = function () {
 	return ViewAnimator;
@@ -81,27 +79,16 @@ var Group = Class(Emitter, function (supr) {
 		for (var id in this._anims) {
 			if (this._anims[id].hasFrames()) { return true; }
 		}
-
 		return false;
 	};
 
 	this.onAnimationFinish = function (anim) {
-		delete this._anims[anim.id];
-
 		if (!this.isActive()) {
 			// if called from a Finish event, republish it
 			this.publish('Finish');
 		}
 	};
 });
-
-var groups = {
-	0: new Group()
-};
-
-exports.getGroup = function (i) {
-	return groups[i || 0];
-};
 
 var TRANSITIONS = [
 	transitions.easeInOut,         // 0: default

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -418,6 +418,12 @@ var Animator = exports.Animator = Class(Emitter, function () {
 
 		// nothing left in the queue!
 		this._unschedule();
+		this._onFinish();
+	};
+
+	// fire a 'Finish' event when all queued frames complete
+	this._onFinish = function () {
+		this.publish('Finish');
 	};
 });
 

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -114,10 +114,9 @@ exports.setViewAnimator = function (ctor) { ViewAnimator = ctor; };
  *     all animations in the group complete, for example:
  *     myGroup.once('Finish', function () { ... });
  * - exposes clear, commit, pause, and resume to apply to all group animations
- * - creating or resetting a group traverses your view hierarchy
- * - saving a group will also save any subjects from being garbage collected
+ * - WARNING: creating or resetting a group traverses your view hierarchy
+ * - WARNING: saving a group will also save subjects (from garbage collection)
  */
-
 var Group = Class(Emitter, function () {
 	this.init = function (groupID) {
 		this.groupID = groupID;
@@ -137,7 +136,9 @@ var Group = Class(Emitter, function () {
 			var id = viewIDs[i];
 			var view = View.findViewByID(id);
 			var anim = view && view.__anims && view.__anims[this.groupID];
-			anim && this._add(anim);
+			if (anim && anim.hasFrames()) {
+				this._add(anim);
+			}
 		}
 
 		// find all animating non-view subjects in the group
@@ -187,6 +188,17 @@ var Group = Class(Emitter, function () {
 		return this._isFinished;
 	};
 
+	// are there any active animations in the group?
+	this.isActive = function () {
+		var anims = this.anims;
+		for (var i = 0; i < anims.length; i++) {
+			if (anims[i].hasFrames()) {
+				return true;
+			}
+		}
+		return false;
+	};
+
 	// clear all the animations in the group
 	this.clear = function () {
 		var anims = this.anims;
@@ -228,8 +240,12 @@ var Group = Class(Emitter, function () {
 	};
 });
 
-// please see Group Class notes above!
-// returns a new Group containing a set of Animators w the same groupID
+/**
+ * See Group Class notes above!
+ * - returns a new Group containing a set of Animators w the same groupID
+ * - WARNING: creating or resetting a group traverses your view hierarchy
+ * - WARNING: saving a group will also save subjects (from garbage collection)
+ */
 exports.getGroup = function (groupID) {
 	return new Group('' + (groupID || DEFAULT_GROUP_ID));
 };

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -20,7 +20,6 @@
  * Canvas animate namespace and functions.
  */
 
-import lib.Callback as Callback;
 import event.Emitter as Emitter;
 import animate.transitions as transitions;
 import timer;
@@ -52,10 +51,9 @@ exports = function (subject, groupID) {
 		anim = subject instanceof View
 			? new ViewAnimator(subject)
 			: new Animator(subject);
+		anim.groupID = groupID;
 		anims[groupID] = anim;
 	}
-
-	anim.groupID = groupID;
 
 	return anim;
 };

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -312,9 +312,6 @@ var CallbackFrame = Class(Frame, function () {
 	};
 });
 
-// a wait frame is just a frame that does nothing... so don't do anything!
-var WaitFrame = Frame;
-
 var ObjectFrame = Class(Frame, function () {
 	this.exec = function (tt, t, debug) {
 		// set starting values on first execution
@@ -454,7 +451,7 @@ var Animator = exports.Animator = Class(Emitter, function () {
 		} else if (targetType === 'object') {
 			return new ObjectFrame(opts);
 		} else {
-			return new WaitFrame(opts);
+			return new Frame(opts);
 		}
 	};
 

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -119,7 +119,7 @@ exports.setViewAnimator = function (ctor) { ViewAnimator = ctor; };
  */
 var Group = Class(Emitter, function () {
 	this.init = function (groupID) {
-		this.groupID = groupID;
+		this.groupID = groupID + '';
 		this.anims = [];
 		this.reset();
 	};
@@ -183,7 +183,7 @@ var Group = Class(Emitter, function () {
 		this.publish('Finish');
 	};
 
-	// have all the animations in the group completed?
+	// has the 'Finish' callback already fired?
 	this.isFinished = function () {
 		return this._isFinished;
 	};
@@ -247,7 +247,7 @@ var Group = Class(Emitter, function () {
  * - WARNING: saving a group will also save subjects (from garbage collection)
  */
 exports.getGroup = function (groupID) {
-	return new Group('' + (groupID || DEFAULT_GROUP_ID));
+	return new Group(groupID || DEFAULT_GROUP_ID);
 };
 
 var TRANSITIONS = [

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -39,7 +39,7 @@ exports = function (subject, groupID) {
 	}
 
 	// animators created once and cached on subject '__anims' object by groupID
-	// so they're only garbage-collected when the subject is garbage collected
+	// so they're only garbage collected when the subject is garbage collected
 	var groupID = groupID || 0;
 	var animID = subject.__anim_id || (subject.__anim_id = '__anim_' + (++uid));
 	var anims = subject.__anims || (subject.__anims = {});

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -38,6 +38,8 @@ exports = function (subject, groupID) {
 		return subject.getAnimation();
 	}
 
+	// animators created once and cached on subject '__anims' object by groupID
+	// so they're only garbage-collected when the subject is garbage collected
 	var groupID = groupID || 0;
 	var animID = subject.__anim_id || (subject.__anim_id = '__anim_' + (++uid));
 	var anims = subject.__anims || (subject.__anims = {});

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -41,11 +41,11 @@ exports = function (subject, groupID) {
 	}
 
 	// create a group for this groupID if it doesn't exist
+	groupID = groupID || DEFAULT_GROUP_ID;
 	!groups[groupID] && (groups[groupID] = new Group(groupID));
 
 	// animators created once and cached on subject '__anims' object by groupID
 	// so they're only garbage collected when the subject is garbage collected
-	groupID = groupID || DEFAULT_GROUP_ID;
 	var anims = subject.__anims || (subject.__anims = {});
 	var anim = anims[groupID];
 	if (!anim) {
@@ -517,15 +517,13 @@ var Animator = exports.Animator = Class(Emitter, function () {
 	};
 
 	this._addToGroup = function () {
-		if (this.groupID) {
-			groups[this.groupID].add(this);
-		}
+		var group = groups[this.groupID];
+		group && group.add(this);
 	};
 
 	this._removeFromGroup = function () {
-		if (this.groupID) {
-			groups[this.groupID].remove(this);
-		}
+		var group = groups[this.groupID];
+		group && group.remove(this);
 	};
 });
 

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -105,7 +105,19 @@ exports.resumeSubjectAnimations = function (subject) {
 exports.getViewAnimator = function () { return ViewAnimator; };
 exports.setViewAnimator = function (ctor) { ViewAnimator = ctor; };
 
-// class for tracking sets of animations w same groupID across different subjects
+/**
+ * Group Class
+ * - finds animations w the same groupID across different subjects
+ * - created and returned by animate.getGroup()
+ * - reset populates the group with all active animations w matching groupID
+ * - subscribe to the 'Finish' event to fire a callback when
+ *     all animations in the group complete, for example:
+ *     myGroup.once('Finish', function () { ... });
+ * - exposes clear, commit, pause, and resume to apply to all group animations
+ * - creating or resetting a group traverses your view hierarchy
+ * - saving a group will also save any subjects from being garbage collected
+ */
+
 var Group = Class(Emitter, function () {
 	this.init = function (groupID) {
 		this.groupID = groupID;
@@ -206,6 +218,7 @@ var Group = Class(Emitter, function () {
 	};
 });
 
+// please see Group Class notes above!
 // returns a new Group containing a set of Animators w the same groupID
 exports.getGroup = function (groupID) {
 	return new Group('' + (groupID || DEFAULT_GROUP_ID));

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -135,8 +135,8 @@ var TRANSITIONS = [
 	transitions.easeInBack,        // 29
 	transitions.easeOutBack,       // 30
 	transitions.easeInOutBack,     // 31
-	transitions.easeOutBounce,     // 32
-	transitions.easeInBounce,      // 33
+	transitions.easeInBounce,      // 32
+	transitions.easeOutBounce,     // 33
 	transitions.easeInOutBounce    // 34
 ];
 

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -102,9 +102,38 @@ exports.resumeSubjectAnimations = function (subject) {
 	}
 };
 
-// used to get/set native or browser ViewAnimator constructors
-exports.getViewAnimator = function () { return ViewAnimator; };
-exports.setViewAnimator = function (ctor) { ViewAnimator = ctor; };
+// clear all animations globally
+exports.clearAllAnimations = function () {
+	for (var id in groups) {
+		groups[id].clear();
+	}
+};
+
+// commit all animations globally
+exports.commitAllAnimations = function () {
+	for (var id in groups) {
+		groups[id].commit();
+	}
+};
+
+// pause all animations globally
+exports.pauseAllAnimations = function () {
+	for (var id in groups) {
+		groups[id].pause();
+	}
+};
+
+// resume all animations globally
+exports.resumeAllAnimations = function () {
+	for (var id in groups) {
+		groups[id].resume();
+	}
+};
+
+// see Group Class notes below
+exports.getGroup = function (groupID) {
+	return groups[groupID || DEFAULT_GROUP_ID];
+};
 
 /**
  * Group Class
@@ -182,13 +211,6 @@ var Group = Class(Emitter, function () {
 		return this;
 	};
 });
-
-/**
- * See Group Class notes above!
- */
-exports.getGroup = function (groupID) {
-	return groups[groupID || DEFAULT_GROUP_ID];
-};
 
 var TRANSITIONS = [
 	transitions.easeInOut,         // 0: default
@@ -536,3 +558,7 @@ var ViewAnimator = Class(Animator, function () {
 		}
 	};
 });
+
+// used to get/set native or browser ViewAnimator constructors
+exports.getViewAnimator = function () { return ViewAnimator; };
+exports.setViewAnimator = function (ctor) { ViewAnimator = ctor; };

--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -484,6 +484,7 @@ var Animator = exports.Animator = Class(Emitter, function () {
 	};
 
 	this.commit = function () {
+		this.resume();
 		this._elapsed = 0;
 		for (var i = 0, p; p = this._queue[i]; ++i) {
 			this._elapsed += p.duration;


### PR DESCRIPTION
* Animators for a specific subject and group ID are created once and only once
* Animators are stored on the subject itself in the '__anims' cache object
	* replaces internal animate groups cache
	* this way Animators are garbage collected only when their subject is garbage collected
* fixes native animate commit bug