### PR TITLE
fix multi touch scroll

### DIFF
--- a/src/ui/ScrollView.js
+++ b/src/ui/ScrollView.js
@@ -377,6 +377,7 @@ exports = Class(View, function (supr) {
 			this.startDrag({radius: this._opts.dragRadius * this._snapPixels});
 
 			if (this._anim && this._anim.hasFrames()) {
+				this._contentView.getInput().blockEvents = false;
 				this._anim.clear();
 			}
 

--- a/src/ui/ScrollView.js
+++ b/src/ui/ScrollView.js
@@ -408,10 +408,7 @@ exports = Class(View, function (supr) {
 	};
 
 	this.onDragStop = function (dragEvt, selectEvt) {
-		this._contentView.getInput().blockEvents = false;
-
 		if (this._opts.inertia) {
-
 			//how much of the current event
 			//should be favored over older events in the running
 			//weighted average being computed
@@ -492,11 +489,14 @@ exports = Class(View, function (supr) {
 						offset.y + delta.y * tt);
 				}), time * TIME_MULTIPLIER, animate.easeOut).then(bind(this, function () {
 					this._endBounce(offset);
+					this._contentView.getInput().blockEvents = false;
 				}));
+				return;
 			} else {
 				this._endBounce(offset);
 			}
 		}
+		this._contentView.getInput().blockEvents = false;
 	};
 
 


### PR DESCRIPTION
Events should be re-enabled only after scroll animation is complete, otherwise user will be able to select elements in content view while inertia.