### PR TITLE
fix (ImageScaleView): add urlChanged event to image

### DIFF
--- a/src/ui/resource/Image.js
+++ b/src/ui/resource/Image.js
@@ -272,6 +272,7 @@ exports = Class(lib.PubSub, function () {
 	this.setURL = function (url, forceReload) {
 		resourceLoader._updateImageMap(this._map, url);
 		this._setSrcImg(null, this._map.url, forceReload);
+		this.emit('urlChanged');
 	};
 
 	this.getWidth = function () {


### PR DESCRIPTION
ImageScaleView requires a `urlChanged` event that was never being called (from
inside timestep). Now setting the url on an image emits a `urlChanged` event,
enabling ImageScaleView functionality.