### PR TITLE
TextEditView now displays text even after losing focus.

### DIFF
--- a/src/platforms/browser/EditText.js
+++ b/src/platforms/browser/EditText.js
@@ -83,12 +83,12 @@ var InputField = Class(squill.Widget, function (supr) {
 			ev.height = device.screen.height;
 			window.dispatchEvent(ev);
 		}
+		_focused && _focused.closeEditField();
 		_focused = null;
-		//_focused && _focused.closeEditField();
 	}
 
 	this.setFontColor = function (color) {
-		this._el.style.color = this._opts.color;
+		this._el.style.color = color;
 	}
 
 	this.setHorizontalPadding = function (left, right) {


### PR DESCRIPTION
Issue: `TextEditView` shows the entered text only when it has focus.
Fix:
`_focused.closeEditField()` needs to be called `onBlur` to make the text visible.
`setFontColor` wasn't setting the correct passed in argument.