### PR TITLE
Fixing bug in TextManager caching and texture disposal

### DIFF
--- a/src/platforms/browser/webgl/TextManager.js
+++ b/src/platforms/browser/webgl/TextManager.js
@@ -18,12 +18,12 @@ exports = Class(function () {
     var fontData = Font.parse(font);
     if (!isFontLoaded(fontData.getOrigName())) { return; }
 
-    var key = (stroked
+    var bufferKey = (stroked
           ? ctx.lineWidth + '|' + ctx.strokeStyle + '|'
           : '-|' + ctx.fillStyle)
       + '|' + font + '|' + text;
 
-    if (!this._buffers[key]) {
+    if (!this._buffers[bufferKey]) {
       if (this._numBuffers > MAX_BUFFERS) {
         var oldest = Infinity;
         var oldestKey = null;
@@ -43,15 +43,15 @@ exports = Class(function () {
 
       var canvas = document.createElement('canvas');
       canvas.complete = true;
-      this._buffers[key] = {
+      this._buffers[bufferKey] = {
         lastUsed: 0,
         image: canvas,
         metrics: this._render(canvas, text, font, stroked, ctx.fillStyle, ctx.strokeStyle, ctx.lineWidth)
       };
     }
 
-    this._buffers[key].lastUsed = timer.now;
-    return this._buffers[key];
+    this._buffers[bufferKey].lastUsed = timer.now;
+    return this._buffers[bufferKey];
   };
 
   this._render = function (canvas, text, font, stroked, fillStyle, strokeStyle, lineWidth) {

--- a/src/platforms/browser/webgl/WebGLContext2D.js
+++ b/src/platforms/browser/webgl/WebGLContext2D.js
@@ -212,7 +212,7 @@ var GLManager = Class(function() {
 
 		gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
 
-		this.textureCache = [];
+		this.textureCache = {};
 		this._drawIndex = -1;
 		this._batchIndex = -1;
 

--- a/src/platforms/browser/webgl/WebGLContext2D.js
+++ b/src/platforms/browser/webgl/WebGLContext2D.js
@@ -111,6 +111,7 @@ var getColor = function(key) {
 var GLManager = Class(function() {
 
 	var MAX_BATCH_SIZE = 1024;
+	var CACHE_UID = 0;
 
 	this.init = function () {
 		var webglSupported = false;
@@ -394,7 +395,7 @@ var GLManager = Class(function() {
 		var gl = this.gl;
 		if (!gl) { return -1; }
 
-		if (!id) { id = this.textureCache.length; }
+		if (!id) { id = CACHE_UID++; }
 		var texture = this.textureCache[id] || gl.createTexture();
 
 		gl.bindTexture(gl.TEXTURE_2D, texture);
@@ -420,7 +421,7 @@ var GLManager = Class(function() {
 
 	this.deleteTexture = function(id) {
 		var texture = this.textureCache[id];
-		this._gl.deleteTexture(texture);
+		this.gl.deleteTexture(texture);
 		delete this.textureCache[id];
 	};
 
@@ -910,7 +911,9 @@ var Context2D = Class(function () {
 
 	this.deleteTextureForImage = function(canvas) {
 		if (!this._manager.gl) { return; }
+		this._manager.flush();
 		this._manager.deleteTexture(canvas.__GL_ID);
+		canvas.__GL_ID = undefined;
 	};
 
 });


### PR DESCRIPTION
This solves 2 things, the first being a same-named variable causing the text manager cache to wipe itself out, and the second making sure the WebGL context renders out pending textures before disposing of them.