### PR TITLE
Adding one line so that images can be used cross origin in webgl mode.

### DIFF
--- a/src/ui/resource/Image.js
+++ b/src/ui/resource/Image.js
@@ -141,6 +141,7 @@ exports = Class(lib.PubSub, function () {
 		// create an image if we don't have one
 		if (!img) {
 			img = new Image();
+			img.crossOrigin = "anonymous";
 		}
 
 		this._srcImg = img;


### PR DESCRIPTION
Currently cross-origin images work in canvas mode but not in webgl mode (even when CORS headers are set properly).  This one line change will allow cross-origin-images to be used when running in webgl mode.  