### PR TITLE
Misc fixes

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -146,6 +146,8 @@ if (exports.isMobile) {
 		exports.name = 'browser';
 		exports.isMobileBrowser = true;
 		exports.isIOS = true;
+		exports.isIpad = /iPad/i.test(ua);
+		exports.isStandalone = !!window.navigator.standalone; // full-screen
 
 		var match = ua.match(/iPhone OS ([0-9]+)/);
 		exports.iosVersion = match && parseInt(match[1]);

--- a/src/platforms/browser/initialize.js
+++ b/src/platforms/browser/initialize.js
@@ -27,7 +27,7 @@ exports.init = function () {
 		var width = (window.innerWidth || (doc.clientWidth || doc.clientWidth)) * dpr;
 		var height = (window.innerHeight || (doc.clientHeight || doc.clientHeight)) * dpr;
 
-		if (width != device.width || height != device.height) {
+		if (width != device.width || height != device.height || !device.screen.orientation) {
 			device.width = width;
 			device.height = height;
 			device.screen.width = width;

--- a/src/ui/Engine.js
+++ b/src/ui/Engine.js
@@ -125,7 +125,8 @@ var Engine = exports = Class(Emitter, function (supr) {
 		this._inputListener = new dispatch.InputListener({
 			rootView: this._view,
 			el: this._rootElement,
-			keyListener: this._keyListener
+			keyListener: this._keyListener,
+			engine: this
 		});
 
 		this._reflowMgr = ReflowManager.get();
@@ -147,6 +148,10 @@ var Engine = exports = Class(Emitter, function (supr) {
 		}
 
 		this.updateOpts(this._opts);
+	};
+
+	this.getOpt = function (key) {
+		return this._opts[key];
 	};
 
 	this.updateOpts = function (opts) {

--- a/src/ui/ImageScaleView.js
+++ b/src/ui/ImageScaleView.js
@@ -24,6 +24,7 @@
 import ui.View;
 import ui.resource.Image as Image;
 import ui.resource.loader as resourceLoader;
+import ui.resource.ImageViewCache as ImageViewCache;
 
 exports = Class(ui.View, function (supr) {
 
@@ -317,12 +318,13 @@ exports = Class(ui.View, function (supr) {
 		return this._img;
 	};
 
-	this.setImage = function (img) {
+	this.setImage = function (img, opts) {
 		this._renderCacheKey = {};
 
 		var autoSized = false;
 		var sw, sh, iw, ih, bounds;
-		var opts = this._opts;
+		var viewOpts = this._opts;
+		var forceReload = opts && opts.forceReload;
 
 		if (typeof img == 'string') {
 			bounds = resourceLoader.getMap()[img];
@@ -330,26 +332,27 @@ exports = Class(ui.View, function (supr) {
 				iw = bounds.w + bounds.marginLeft + bounds.marginRight;
 				ih = bounds.h + bounds.marginTop + bounds.marginBottom;
 			}
-		} else if (img instanceof Image && img.isLoaded()) {
-			bounds = img.getBounds();
-			iw = bounds.width + bounds.marginLeft + bounds.marginRight;
-			ih = bounds.height + bounds.marginTop + bounds.marginBottom;
-		}
 
-		if (!bounds) {
-			if (typeof img == 'string') {
-				img = new Image({url: img});
-			}
-
-			if (img) {
-				if (!img.isError()) {
-					img.doOnLoad(this, 'setImage', img);
-				}
-				return;
+			// resolve to object
+			img = ImageViewCache.getImage(img, forceReload);
+		} else if (img instanceof Image) {
+			if (forceReload) {
+				img.reload();
+			} else if (img.isLoaded()) {
+				bounds = img.getBounds();
+				iw = bounds.width + bounds.marginLeft + bounds.marginRight;
+				ih = bounds.height + bounds.marginTop + bounds.marginBottom;
 			}
 		}
 
-		if (opts.autoSize && this._scaleMethod == 'stretch' && !((opts.width || opts.layoutWidth) && (opts.height || opts.layoutHeight))) {
+		if (img && !bounds) {
+			if (!img.isError()) {
+				img.doOnLoad(this, 'setImage', img);
+			}
+			return;
+		}
+
+		if (viewOpts.autoSize && this._scaleMethod == 'stretch' && !((viewOpts.width || viewOpts.layoutWidth) && (viewOpts.height || viewOpts.layoutHeight))) {
 			autoSized = true;
 			if (this.style.fixedAspectRatio) {
 				this.style.enforceAspectRatio(iw, ih);
@@ -359,9 +362,9 @@ exports = Class(ui.View, function (supr) {
 			}
 		}
 
-		this._opts.image = this._img = (typeof img == 'string') ? new Image({url: img}) : img;
+		viewOpts.image = this._img = img;
 
-		if (this._img) {
+		if (img) {
 			if (this._isSlice) {
 				this.updateSlices();
 
@@ -393,11 +396,11 @@ exports = Class(ui.View, function (supr) {
 				});
 			}
 
-			if (opts && opts.autoSize && !autoSized) {
-				this._img.doOnLoad(this, 'autoSize');
+			if (viewOpts.autoSize && !autoSized) {
+				img.doOnLoad(this, 'autoSize');
 			}
 
-			this._img.doOnLoad(this, 'needsRepaint');
+			img.doOnLoad(this, 'needsRepaint');
 		}
 	};
 

--- a/src/ui/ImageScaleView.js
+++ b/src/ui/ImageScaleView.js
@@ -43,6 +43,15 @@ exports = Class(ui.View, function (supr) {
 		return this._scaleMethod;
 	};
 
+	function adjustMiddleSlice(slices) {
+		if (slices[1] < 0) {
+			var overshoot = -slices[1] + 1;
+			slices[1] = 1;
+			slices[0] -= Math.floor(overshoot / 2);
+			slices[2] -= Math.ceil(overshoot / 2);
+		}
+	}
+
 	this.updateSlices = function (opts) {
 		opts = opts || this._opts;
 
@@ -94,6 +103,7 @@ exports = Class(ui.View, function (supr) {
 			if (src.center == undefined && this._img) { // also captures null, but ignores 0
 				var width = this._img.getWidth();
 				slices[1] = width ? width - slices[0] - slices[2] : 0;
+				adjustMiddleSlice(slices);
 			}
 
 			this._sourceSlicesHor = slices;
@@ -113,6 +123,7 @@ exports = Class(ui.View, function (supr) {
 			if (src.middle == undefined && this._img) {
 				var height = this._img.getHeight();
 				slices[1] = height ? height - slices[0] - slices[2] : 0;
+				adjustMiddleSlice(slices);
 			}
 
 			this._sourceSlicesVer = slices;

--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -40,8 +40,6 @@ import animate;
 
 import util.setProperty;
 
-var KeyListener = device.get('KeyListener');
-
 var EventScheduler = Class(function () {
 	this.init = function () {
 		this._queue = [];
@@ -70,7 +68,6 @@ var scheduler = new EventScheduler();
  */
 var FocusMgr = new (Class(function () {
 	this.init = function (opts) {
-		this._keyListener = KeyListener && (new KeyListener());
 		this._target = null;
 		this._canChange = true;
 	};
@@ -94,13 +91,6 @@ var FocusMgr = new (Class(function () {
 	this.blur = function (target) {
 		target.onBlur && target.onBlur(this);
 		this._target = false;
-	};
-
-	/**
-	 * Return the keylistener used by the focus manager.
-	 */
-	this.getKeyListener = function () {
-		return this._keyListener;
 	};
 
 	this.get = function () {

--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -632,7 +632,7 @@ var View = exports = Class(Emitter, function () {
 	 */
 	this.getEngine = this.getApp = function () {
 		return this.__root;
-	}
+	};
 
 	/**
 	 * Returns an array of all ancestors of the current view.

--- a/src/ui/backend/canvas/ImageView.js
+++ b/src/ui/backend/canvas/ImageView.js
@@ -23,17 +23,16 @@
 import util.path;
 import std.uri as URI;
 
-import ui.View as View
+import ui.View as View;
 import ui.resource.Image as Image;
-
-var imageCache = {};
+import ui.resource.ImageViewCache as ImageViewCache;
 
 /**
  * @extends ui.View
  */
 var ImageView = exports = Class(View, function (supr) {
 
-	/** 
+	/**
 	 * Options:
 	 *   autoSize - See .setImage()
 	 */
@@ -46,23 +45,14 @@ var ImageView = exports = Class(View, function (supr) {
 		return this._img;
 	};
 
+	// @deprecated
 	this.getImageFromCache = function(url, forceReload) {
-		var img;
-		if (!forceReload) {
-			img = imageCache[url];
-		}
-		if (!img) {
-			imageCache[url] = img = new Image({
-				url: url,
-				forceReload: !!forceReload
-			});
-		}
-		return img;
+		return ImageViewCache.getImage(url, forceReload);
 	};
 
 	this.updateOpts = function (opts) {
 		var opts = supr(this, 'updateOpts', arguments);
-		
+
 		if ('autoSize' in opts) {
 			this._autoSize = !!opts.autoSize;
 		}
@@ -74,7 +64,7 @@ var ImageView = exports = Class(View, function (supr) {
 		}
 
 		return opts;
-	}
+	};
 
 	/**
 	 * Set the image of the view from an Image object or string.
@@ -85,7 +75,9 @@ var ImageView = exports = Class(View, function (supr) {
 	this.setImage = function (img, opts) {
 		var forceReload = opts && opts.forceReload;
 		if (typeof img == 'string') {
-			img = this.getImageFromCache(img, forceReload);
+			img = ImageViewCache.getImage(img, forceReload);
+		} else if (forceReload) {
+			img.reload();
 		}
 
 		this._img = img;
@@ -109,7 +101,7 @@ var ImageView = exports = Class(View, function (supr) {
 	 * Pass a function to load once the Image object is loaded, or a list of
 	 * arguments that call lib.Callback::run() implicitly.
 	 */
-	
+
 	this.doOnLoad = function () {
 		if (arguments.length == 1) {
 			this._img.doOnLoad(this, arguments[0]);
@@ -122,7 +114,7 @@ var ImageView = exports = Class(View, function (supr) {
 	/**
 	 * Automatically resize the view to the size of the image.
 	 */
-	
+
 	this.autoSize = function () {
 		if (this._img) {
 			this.style.width = this._img.getWidth();
@@ -137,7 +129,7 @@ var ImageView = exports = Class(View, function (supr) {
 	/**
 	 * Get original width of the Image object.
 	 */
-	
+
 	this.getOrigWidth = this.getOrigW = function () {
 		return this._img.getOrigW();
 	};

--- a/src/ui/backend/canvas/ViewBacking.js
+++ b/src/ui/backend/canvas/ViewBacking.js
@@ -22,9 +22,6 @@
 
 import ..strPad;
 import ..BaseBacking;
-import util.setProperty as setProperty;
-
-var _styleKeys = {};
 
 var ViewBacking = exports = Class(BaseBacking, function () {
 	var IDENTITY_MATRIX = { a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0 };

--- a/src/ui/resource/Image.js
+++ b/src/ui/resource/Image.js
@@ -197,14 +197,23 @@ exports = Class(lib.PubSub, function () {
 				cb = cb.chain();
 			}
 
+			var hasFired = this._cb.fired();
+
 			// GC native has a reload method to force reload
 			if (srcImg.reload) {
 				var onReload = bind(this, function () {
 					srcImg.removeEventListener('reload', onReload, false);
+					if (hasFired) {
+						this._cb.fire(null, this);
+					}
 					cb && cb();
 				});
 				srcImg.addEventListener('reload', onReload, false);
 				srcImg.reload();
+
+				if (hasFired) {
+					this._cb.reset();
+				}
 			} else if (cb) {
 				if (this._cb.fired()) {
 					// always wait a frame before calling the callback
@@ -460,3 +469,4 @@ exports = Class(lib.PubSub, function () {
 exports.__clearCache__ = function () {
   ImageCache = {};
 };
+

--- a/src/ui/resource/ImageViewCache.js
+++ b/src/ui/resource/ImageViewCache.js
@@ -1,0 +1,24 @@
+import .Image;
+
+// cache of Images for ImageView and ImageScaleView
+exports.cache = {};
+
+exports.clear = function () {
+  exports.cache = {};
+}
+
+exports.getImage = function (url, forceReload) {
+  var img;
+  if (!forceReload) {
+    img = exports.cache[url];
+  }
+
+  if (!img) {
+    img = exports.cache[url] = new Image({
+      url: url,
+      forceReload: !!forceReload
+    });
+  }
+
+  return img;
+};


### PR DESCRIPTION
## enable scrolling on landscape ios >= 7

Allows scrolling out the address bar when in an iphone mobile browser in
the landscape orientation

By default we allow landscape scrolling in iOS 7+, but iOS 7 does not
have friendly UX for landscape since tapping anywhere near the top or
bottom of the screen will use make the navbar appear.  Thus, for many
games, it is desirable to leave the navbar open all the time on iOS 7
(even though the viewport will be very small), disabling scrolling
completely.  To disable scrolling, use
`Application._settings.minIOSLandscapeScroll` to set the min version for
which landscape scrolling.  Set `disableIOSLandscapeScroll` to disable
this feature completely.

src/Application:
```
  exports = Class(ui.View, function () {
    // disable ios landscape scrolling in iOS 7, only allow 8+
    this._settings = {
      minIOSLandscapeScroll: 8
    };
  });
```

Note that landscape scrolling is only relevant for web builds (iOS
mobile safari) on iPhones (or iPods), not iPads and not standalone web
browsers (e.g. home screen website or embedded web view).

## misc fixes

 - Image cache refactored from ImageView into separate file and shared with ImageScaleView
 - default KeyListener removed (blocks key presses on a page with an embedded game)
 - ui.resource.Image does nothing on `render()` if the error flag was set
 - ImageScaleView 9slice corrects a negative middle slice size (try to render a best-attempt when the slices are larger than the image)