### PR TITLE
Modified to fix issue of delay b/w animation loop in not applying.

### DIFF
--- a/src/ui/SpriteView.js
+++ b/src/ui/SpriteView.js
@@ -237,7 +237,7 @@ var SpriteView = exports = Class("SpriteView", ImageView, function (logger, supr
     if (!this._opts.loop) {
       this.stopAnimation();
     } else {
-      this.startAnimation(this._opts.defaultAnimation);
+      this.startAnimation(this._opts.defaultAnimation, this._opts);
     }
   };
 


### PR DESCRIPTION
Suppose a SpriteView instance is created with default animation and delay and another animation is triggered by startAnimation function, when it comes back to default animation, delay specified was not being applied b/w animation loops.
