### PR TITLE
fix for isPlaying always returning false

### DIFF
--- a/src/AudioManager.js
+++ b/src/AudioManager.js
@@ -311,6 +311,7 @@ var MultiSound = Class(function () {
       }
       this._lastSrc = src;
     }
+    this._isPaused = false;
   };
 
   this._playFromBuffer = function (buffer, loop, time, duration) {


### PR DESCRIPTION
This is a fix for isPlaying() always returning false because _isPaused is never set to false.