### PR TITLE
fix(image): fix an issue with base64 images

### DIFF
--- a/src/ui/resource/Image.js
+++ b/src/ui/resource/Image.js
@@ -147,7 +147,9 @@ exports = Class(lib.PubSub, function () {
     // create an image if we don't have one
     if (!img) {
       img = new Image();
-      img.crossOrigin = 'use-credentials';
+      if (!url || !url.startsWith('data:image')) {
+        img.crossOrigin = 'use-credentials';
+      }
     }
 
     this._srcImg = img;

--- a/src/ui/resource/Image.js
+++ b/src/ui/resource/Image.js
@@ -147,7 +147,7 @@ exports = Class(lib.PubSub, function () {
     // create an image if we don't have one
     if (!img) {
       img = new Image();
-      if (!url || !url.startsWith('data:image')) {
+      if (!url || url.indexOf('data:image/png') === -1) {
         img.crossOrigin = 'use-credentials';
       }
     }


### PR DESCRIPTION
Fixes an issue where a cross origin tag was being added to base64 images which generally caused them not to render in safari on ios.