### PR TITLE
Fix for clear paused animation

### DIFF
--- a/src/ui/backend/canvas/animate.js
+++ b/src/ui/backend/canvas/animate.js
@@ -433,6 +433,7 @@ var Animator = exports.Animator = Class(Emitter, function () {
     }
     queue.length = 0;
     this._elapsed = 0;
+    this._isPaused = false;
     this._unschedule();
     this._removeFromGroup();
     return this;


### PR DESCRIPTION
If you try call `animate(...).clear()` on paused animation, next call  `animate(...).pause()` won't work.
This happens because `clear()` doesn't reset paused state for the object.