### PR TITLE
Optimization of BaseBacking class

### DIFF
--- a/src/ui/backend/BaseBacking.js
+++ b/src/ui/backend/BaseBacking.js
@@ -16,37 +16,61 @@
 
 import setProperty from 'util/setProperty';
 
-// keys map to properties
-var BASE_STYLE_PROPS = {
-  'x': { value: 0 },
-  'y': { value: 0 },
-  // translate
-  'offsetX': { value: 0 },
-  'offsetY': { value: 0 },
-  // rotation and scale
-  'anchorX': { value: 0 },
-  'anchorY': { value: 0 },
-  'centerAnchor': { value: false },
-  'width': { cb: '_onResize' },
-  'height': { cb: '_onResize' },
-  'r': { value: 0 },
-  'opacity': { value: 1 },
-  'zIndex': {
-    value: 0,
-    cb: '_onZIndex'
-  },
-  'scale': { value: 1 },
-  'scaleX': { value: 1 },
-  'scaleY': { value: 1 },
-  'flipX': { value: false },
-  'flipY': { value: false },
-  'visible': { value: true },
-  'clip': { value: false },
-  'backgroundColor': { value: '' },
-  'compositeOperation': { value: '' }
-};
-
 export default class BaseBacking {
+
+  constructor () {
+    this.x = 0;
+    this.y = 0;
+    this.offsetX = 0;
+    this.offsetY = 0;
+    this.anchorX = 0;
+    this.anchorY = 0;
+    this.centerAnchor = 0;
+    this._width = 0;
+    this._height = 0;
+    this.r = 0;
+    this.opacity = 1;
+    this._zIndex = 0;
+    this.scale = 1;
+    this.scaleX = 1;
+    this.scaleY = 1;
+    this.flipX = false;
+    this.flipY = false;
+    this.visible = true;
+    this.clip = false;
+    this.backgroundColor = '';
+    this.compositeOperation = '';
+  }
+
+  get width () { return this._width;  }
+  set width (width) {
+    if (this._width === width) {
+      return;
+    }
+    this._width = width;
+    this._onResize();
+  }
+
+
+  get height () { return this._height; }
+  set height (height) {
+    if (this._height === height) {
+      return;
+    }
+    this._height = height;
+    this._onResize();
+  }
+
+
+  get zIndex () { return this._zIndex;  }
+  set zIndex (zIndex) {
+    if (this._zIndex === zIndex) {
+      return;
+    }
+    this._zIndex = zIndex;
+    this._onZIndex('zIndex', zIndex);
+  }
+
 
   localizePoint (pt) {
     pt.x -= this.x + this.anchorX + this.offsetX;
@@ -61,10 +85,32 @@ export default class BaseBacking {
   }
 
   copy () {
-    var copy = {};
+    var copy = {
+      x: this.x,
+      y: this.y,
+      offsetX: this.offsetX,
+      offsetY: this.offsetY,
+      anchorX: this.anchorX,
+      anchorY: this.anchorY,
+      centerAnchor: this.centerAnchor,
+      width: this._width,
+      height: this._height,
+      r: this.r,
+      opacity: this.opacity,
+      zIndex: this._zIndex,
+      scale: this.scale,
+      scaleX: this.scaleX,
+      scaleY: this.scaleY,
+      flipX: this.flipX,
+      flipY: this.flipY,
+      visible: this.visible,
+      clip: this.clip,
+      backgroundColor: this.backgroundColor,
+      compositeOperation: this.compositeOperation
+    };
 
-    for (var i = 0; i < styleKeyList.length; i++) {
-      var key = styleKeyList[i];
+    for (var i = 0; i < extendedStylePropList.length; i++) {
+      var key = extendedStylePropList[i];
       copy[key] = this[key];
     }
 
@@ -72,26 +118,19 @@ export default class BaseBacking {
   }
 
   update (style) {
-    for (var i = 0; i < styleKeyList.length; i++) {
-      var key = styleKeyList[i];
-      if (style[key] !== void 0) {
+    for (var key in style) {
+      if (this[key] !== void 0) {
         this[key] = style[key];
       }
     }
+
     return this;
   }
 
 };
 
-var styleKeys = BaseBacking.prototype.constructor.styleKeys = {};
-var styleKeyList = [];
-
+var extendedStylePropList = [];
 BaseBacking.prototype.constructor.addProperty = function (key, def) {
-  styleKeys[key] = true;
-  styleKeyList.push(key);
+  extendedStylePropList.push(key);
   setProperty(BaseBacking.prototype, key, def);
 };
-
-for (var key in BASE_STYLE_PROPS) {
-  BaseBacking.prototype.constructor.addProperty(key, BASE_STYLE_PROPS[key]);
-}


### PR DESCRIPTION
## Why
The goal of this optimization was to speed up the ```updateGlobalTransformViewBacking```.

I was investigating why the ```ViewBacking.updateGlobalTransform``` method was slower than expected. JavaScript profiling on Everwing was showing around 5.7% of the total execution time was taken by ```updateGlobalTransform``` while I would expect less than 2% for what it does (profiled with main gameplay feature).

## How
I realized that the ```ViewBacking``` instances might not be very well optimized due to properties being attached to the prototype instead of being added as regular properties of the instances.
Therefore the optimization consisted solely in rewriting the definition of the ```BaseBacking``` class.

## Result
#### CPU
Overall, it looks like the CPU usage of ```updateGlobalTransform``` went down to ~2.7%.
Which would indicate a 3% boost for the total but it seems that the refactoring benefits other methods as profiling suggest a 9% reduction of CPU usage: out of 5 run per configuration (before and after refactoring), I get a 16.82% non-idle time before and 15.28% after, which corresponds to a 9% reduction.

***Screen shot of JS profile before:***
<img width="532" alt="screen shot 2017-06-09 at 2 30 28 pm" src="https://user-images.githubusercontent.com/1897225/26962305-414e7f68-4d20-11e7-90e9-b0248de0fc96.png">

***Screen shot of JS profile after:***
<img width="533" alt="screen shot 2017-06-09 at 2 27 05 pm" src="https://user-images.githubusercontent.com/1897225/26962304-414c5832-4d20-11e7-82f1-1e1f7a10e0f7.png">

The above screenshots are characteristic of the behavior that can be noticed across all 10 runs. It is interesting to note that the ```anonymous``` function, located in ```util/setProperty```, went down from 2.4% to ~1%. This method was called indirectly whenever accessing or setting a property with custom getters and setters generated in ```util/setProperty```. A few, frequently accessed, properties of ```BaseBacking``` were set up this way but are not anymore with this refactoring; This explains why this anonymous method is now using less resources.

#### Memory
It appears that the amount of memory used by instances of the class is now smaller but the amount is very negligible.
***Screen shot of memory profile before:***
<img width="715" alt="screen shot 2017-06-09 at 12 13 58 pm" src="https://user-images.githubusercontent.com/1897225/26962024-3f348e54-4d1e-11e7-9f6d-31c3805e1e62.png">
***Screen shot of memory profile after:***
<img width="715" alt="screen shot 2017-06-09 at 12 12 07 pm" src="https://user-images.githubusercontent.com/1897225/26962025-4072b174-4d1e-11e7-8c3d-39546c8a1053.png">


## Notes
- I am not sure whether this refactoring breaks anything. Everwing appears to be running properly.
- The optimization is not contextual and should improve performance in every case.
- The ```updateGlobalTransform``` is still taking too much resources. It must be possible to bring it down to ~30ms for a 10s long profile in the current test conditions. The reason for the extra resource usage remains unknown but it could be that ViewBacking instances are not fully optimized yet. Refactoring the ```BackingExtention``` in a similar way might help the optimizer compiler do a better job when dealing with the ```updateGlobalTransform``` in particular but also with all the ```ViewBacking``` methods in general.
