### PR TITLE
Optimization of wrapTick method

### DIFF
--- a/src/ui/SpriteView.js
+++ b/src/ui/SpriteView.js
@@ -86,7 +86,6 @@ export default class SpriteView extends ImageView {
     this.onScreen = true;
     this.isPlaying = false;
     this.isPaused = false;
-    this.tick = null;
 
     this.resetAllAnimations(opts);
   }
@@ -305,7 +304,6 @@ export default class SpriteView extends ImageView {
 
 
 SpriteView.prototype.defaults = defaults;
-SpriteView.prototype.tick = null;
 SpriteView.allAnimations = {};
 SpriteView.getGroup = SpriteView.prototype.getGroup;
 

--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -147,8 +147,36 @@ exports = class View extends IView {
 
     this.__view._view = this;
 
+    this._tick = null;
+
     this.updateOpts(opts);
   }
+
+  get tick () {
+    // this._tick can be null while "_tick" can exist on the protoype
+    return this._tick || this.__proto__._tick;
+  }
+
+  set tick (tick) {
+    // for some reason "this" can refer to the prototype
+    // of an inherited class, therefore it is necessary
+    // to test for the existence of a view
+    if (tick) {
+      if (this.__view) {
+        this.__view.onTickAdded();
+        this.__view._hasTick = true;
+      }
+      this._tick = tick;
+    } else if (this._tick) {
+      this._tick = null;
+      if (this.__view) {
+        this.__view._hasTick = false;
+        this.__view.onTickRemoved();
+      }
+    }
+  }
+
+
   updateOpts (opts) {
     opts = opts || {};
     if (this._opts) {
@@ -631,7 +659,7 @@ View.prototype.getEngine = View.prototype.getApp;
 View.prototype.getParents = View.prototype.getSuperviews;
 View.prototype.toString = View.prototype.getTag;
 
-// --- render/tick setters ---
+// --- render setter ---
 /**
  * Adds a hook to determine when the "render" property is set.
  */
@@ -639,16 +667,6 @@ setProperty(View.prototype, 'render', {
   value: null,
   cb: function () {
     this.__view && (this.__view.hasJSRender = true);
-  }
-});
-
-/**
- * Adds a hook to determine when the "tick" property is set.
- */
-setProperty(View.prototype, 'tick', {
-  value: null,
-  cb: function () {
-    this.__view && (this.__view.hasJSTick = true);
   }
 });
 


### PR DESCRIPTION
## Why
The `wrapTick` method is taking a significant amount of time to execute with respect to the amount of effective work it is doing.
The problem is that all the views are being iterated and checked for the existence of a "tick" method at every frame.
The idea is to make sure that only the views that "tick" (and directly/indirectly attached to the root) are being iterated at every frame.

## How
Simply by implementing a system where a list of ticking subviews (directly or indirectly) are maintained on each view.

## Result

###  Chrome (macbook) profiling
Before
<img width="391" alt="chrome-before" src="https://user-images.githubusercontent.com/1897225/27066172-23a2ea10-503d-11e7-8e8e-8b1bd11e0bcc.png">

After
<img width="397" alt="chrome-after" src="https://user-images.githubusercontent.com/1897225/27066174-287bf5e0-503d-11e7-929d-67503168b589.png">
The `wrapTick` method in itself went from number 1 to number 6 in the ranking of most consuming methods.


###  Safari (iPhone 7) profiling
Before
<img width="364" alt="no-optim" src="https://user-images.githubusercontent.com/1897225/27066272-d71e14ac-503d-11e7-97a9-6504fffa5720.png">

After
<img width="374" alt="safari-after" src="https://user-images.githubusercontent.com/1897225/27066274-dc72baca-503d-11e7-8fa8-f79b00313174.png">
The `wrapTick` method in itself went from number 1 to number 10.

### Chrome (macbook) measure
Therefore I used `performance.measure()` in order to get a "second opinion" in chrome.
The following images show the average execution duration of one tick of the `Engine` at given time intervals on the landing screen in Everwing.
Before
<img width="271" alt="screen shot 2017-06-13 at 1 45 34 pm" src="https://user-images.githubusercontent.com/1897225/27066549-ea3653e0-503f-11e7-9b95-c80f3c3149c0.png">

After
<img width="274" alt="screen shot 2017-06-13 at 1 44 17 pm" src="https://user-images.githubusercontent.com/1897225/27066552-eda91382-503f-11e7-9f40-572d2073538d.png">

**Note:** I place the measurement around the call to the `tick` function of the engine. Therefore not all the execution time is being accounted for. Event callbacks are probably missing as well as `(program)` execution time.

### Perf improvement when combined with https://github.com/gameclosure/timestep/pull/123
By combining the changes from https://github.com/gameclosure/timestep/pull/123 I could see a clear improvement:
Before
<img width="271" alt="screen shot 2017-06-13 at 1 45 34 pm" src="https://user-images.githubusercontent.com/1897225/27066462-607495fe-503f-11e7-825c-a3fd625075ee.png">

After
<img width="277" alt="screen shot 2017-06-13 at 1 45 03 pm" src="https://user-images.githubusercontent.com/1897225/27066453-4cf2828e-503f-11e7-895a-4ce240019946.png">

Also, I could see a clear improvement of the FPS in gameplay phase on Xperia Z3: went from ~40 to ~50.

It looks like this brings down CPU usage by ~10% during Everwing's gameplay phase with non-idle time of 13.5% (on my machine) in testing condition similar to https://github.com/gameclosure/timestep/pull/123 (down from 15.3%)