### PR TITLE
Optimization of wrapRender method

### DIFF
--- a/src/ui/Engine.js
+++ b/src/ui/Engine.js
@@ -56,6 +56,7 @@ import { getImport } from 'platformImport';
 const KeyListener = getImport('KeyListener');
 const InputListener = getImport('Input');
 
+
 var _timers = [];
 timer.onTick = function (dt) {
   var i = _timers.length;
@@ -392,7 +393,7 @@ exports = class extends Emitter {
     }
 
     this._view.__view.constructor.absScale = 1;
-    this._view.__view.wrapRender(this._ctx, {});
+    this._view.__view.wrapRender(this._ctx);
     this.publish('Render', this._ctx);
 
     if (this._ctx) {

--- a/src/ui/Engine.js
+++ b/src/ui/Engine.js
@@ -56,7 +56,6 @@ import { getImport } from 'platformImport';
 const KeyListener = getImport('KeyListener');
 const InputListener = getImport('Input');
 
-
 var _timers = [];
 timer.onTick = function (dt) {
   var i = _timers.length;

--- a/src/ui/ListView.js
+++ b/src/ui/ListView.js
@@ -237,7 +237,7 @@ exports = class extends ScrollView {
   render (ctx) {
     var viewportChanged = super.render(ctx);
 
-    if (viewportChanged || this._needsModelRender || this.model._needsSort) {
+    if (viewportChanged || this._needsModelRender || this.model._shouldSort) {
       this._needsModelRender = false;
       this.model.render(this.getCurrentViewport());
     }

--- a/src/ui/ListView.js
+++ b/src/ui/ListView.js
@@ -234,12 +234,12 @@ exports = class extends ScrollView {
       this.publish('HeightChanged', maxY);
     }
   }
-  render (ctx, opts) {
-    var viewportChanged = super.render(ctx, opts);
+  render (ctx) {
+    var viewportChanged = super.render(ctx);
 
     if (viewportChanged || this._needsModelRender || this.model._needsSort) {
       this._needsModelRender = false;
-      this.model.render(opts.viewport);
+      this.model.render(this.getCurrentViewport());
     }
   }
 };

--- a/src/ui/ScrollView.js
+++ b/src/ui/ScrollView.js
@@ -123,8 +123,8 @@ var viewportStack = [];
 
 function clippedWrapRender (contentView, backing, ctx) {
   // non-native case only
-  if (backing._visiblesNeedsSort) {
-    backing._visiblesNeedsSort = false;
+  if (backing._shouldSortVisibleSubviews) {
+    backing._shouldSortVisibleSubviews = false;
     backing._visibleSubviews.sort();
   }
 

--- a/src/ui/ScrollView.js
+++ b/src/ui/ScrollView.js
@@ -119,14 +119,13 @@ var defaults = {
   layout: 'box'
 };
 
-function clippedWrapRender (contentView, backing, ctx, opts) {
-  if (!backing.visible) {
-    return;
-  }
+var viewportStack = [];
+
+function clippedWrapRender (contentView, backing, ctx) {
   // non-native case only
-  if (backing._needsSort) {
-    backing._needsSort = false;
-    backing._subviews.sort();
+  if (backing._visiblesNeedsSort) {
+    backing._visiblesNeedsSort = false;
+    backing._visibleSubviews.sort();
   }
 
   ctx.save();
@@ -157,25 +156,24 @@ function clippedWrapRender (contentView, backing, ctx, opts) {
       ctx.fillRect(0, 0, backing.width, backing.height);
     }
 
-    backing._view.render && backing._view.render(ctx, opts);
+    backing._view.render && backing._view.render(ctx);
 
-    var viewport = opts.viewport;
     var subviews = backing._subviews;
 
     var i = 0,
       subview;
     while (subview = subviews[i++]) {
       if (subview == contentView) {
-        clippedWrapRender(contentView, subview.__view, ctx, opts);
+        clippedWrapRender(contentView, subview.__view, ctx);
 
-        // restore the old viewport it was changed
-        opts.viewport = viewport;
+        // restoring viewport
+        viewportStack.pop();
       } else {
         var pos = subview.getPosition(viewport.src);
         getBoundingRectangle(pos);
 
         if (intersect.isRectAndRect(pos, viewport)) {
-          clippedWrapRender(contentView, subview.__view, ctx, opts);
+          clippedWrapRender(contentView, subview.__view, ctx);
         }
 
         if (DEBUG) {
@@ -193,12 +191,10 @@ function clippedWrapRender (contentView, backing, ctx, opts) {
 
 // extend the default backing ctor
 class DEFAULT_BACKING_CTOR extends View.BackingCtor {
-  wrapRender (ctx, opts) {
-    clippedWrapRender(this._view._contentView, this, ctx, opts);
+  wrapRender (ctx) {
+    clippedWrapRender(this._view._contentView, this, ctx);
 
     if (DEBUG) {
-      var viewport = opts.viewport;
-
       ctx.save();
       ctx.translate(this.x + this.anchorX, this.y + this.anchorY);
       if (this.r) {
@@ -210,9 +206,9 @@ class DEFAULT_BACKING_CTOR extends View.BackingCtor {
       ctx.translate(-this.anchorX, -this.anchorY);
 
       ctx.fillStyle = 'rgba(255, 0, 0, 0.2)';
-      ctx.fillRect(viewport.x, viewport.y, viewport.width, viewport.height);
+      ctx.fillRect(this._viewport.x, this._viewport.y, this._viewport.width, this._viewport.height);
 
-      ctx.translate(-viewport.x, -viewport.y);
+      ctx.translate(-this._viewport.x, -this._viewport.y);
 
       ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
       for (var i = 0, bounds; bounds = _debug.bounds[i]; ++i) {
@@ -651,7 +647,10 @@ exports = class extends View {
   getFullHeight () {
     return this._contentView.style.height;
   }
-  render (ctx, opts) {
+  getCurrentViewport () {
+    return viewportStack[viewportStack.length - 1];
+  }
+  render (ctx) {
     var s = this.style;
     var cvs = this._contentView.style;
 
@@ -670,11 +669,12 @@ exports = class extends View {
     viewport.width = s.width * s.scale | 0;
     viewport.height = s.height * s.scale | 0;
 
-    if (opts.viewport) {
-      viewportIntersect(viewport, opts.viewport);
+    var currentViewPort = this.getCurrentViewport();
+    if (currentViewPort) {
+      viewportIntersect(viewport, currentViewPort);
     }
 
-    opts.viewport = viewport;
+    viewportStack.push(viewport);
 
     return viewport.x != x || viewport.y != y || viewport.width != width ||
       viewport.height != height;

--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -663,10 +663,23 @@ View.prototype.toString = View.prototype.getTag;
 /**
  * Adds a hook to determine when the "render" property is set.
  */
-setProperty(View.prototype, 'render', {
-  value: null,
-  cb: function () {
-    this.__view && (this.__view.hasJSRender = true);
+View.prototype._render = null;
+Object.defineProperty(View.prototype, 'render', {
+  get: function () { return this._render; },
+  set: function (render) {
+    if (this._render === render) {
+      return;
+    }
+
+    if (!render) {
+      this._render = null;
+    } else {
+      this._render = render;
+    }
+
+    if (this.__view) {
+      this.__view._hasRender = !!render;
+    }
   }
 });
 

--- a/src/ui/backend/BaseBacking.js
+++ b/src/ui/backend/BaseBacking.js
@@ -80,6 +80,10 @@ export default class BaseBacking {
     this._onZIndex();
   }
 
+  // Abstract methods
+  _onVisible () {}
+  _onResize () {}
+  _onZIndex () {}
 
   localizePoint (pt) {
     pt.x -= this.x + this.anchorX + this.offsetX;

--- a/src/ui/backend/BaseBacking.js
+++ b/src/ui/backend/BaseBacking.js
@@ -36,10 +36,19 @@ export default class BaseBacking {
     this.scaleY = 1;
     this.flipX = false;
     this.flipY = false;
-    this.visible = true;
+    this._visible = true;
     this.clip = false;
     this.backgroundColor = '';
     this.compositeOperation = '';
+  }
+
+  get visible () { return this._visible; }
+  set visible (visible) {
+    if (this._visible === visible) {
+      return;
+    }
+    this._visible = visible;
+    this._onVisible();
   }
 
   get width () { return this._width;  }
@@ -68,7 +77,7 @@ export default class BaseBacking {
       return;
     }
     this._zIndex = zIndex;
-    this._onZIndex('zIndex', zIndex);
+    this._onZIndex();
   }
 
 
@@ -103,7 +112,7 @@ export default class BaseBacking {
       scaleY: this.scaleY,
       flipX: this.flipX,
       flipY: this.flipY,
-      visible: this.visible,
+      visible: this._visible,
       clip: this.clip,
       backgroundColor: this.backgroundColor,
       compositeOperation: this.compositeOperation

--- a/src/ui/backend/canvas/ViewBacking.js
+++ b/src/ui/backend/canvas/ViewBacking.js
@@ -51,14 +51,15 @@ exports = class extends BaseBacking {
     this._view = view;
     this._superview = null;
 
-    this._needsSort = false;
-    this._visiblesNeedsSort = false;
+    this._shouldSort = false;
+    this._shouldSortVisibleSubviews = false;
 
     this._subviews = [];
     this._visibleSubviews = [];
 
     // number of direct or indirect tick methods
     this._hasTick = !!view._tick;
+    this._hasRender = !!view._render;
     this._subviewsWithTicks = null;
 
     this._addedAt = 0;
@@ -69,8 +70,8 @@ exports = class extends BaseBacking {
   }
 
   getSubviews () {
-    if (this._needsSort) {
-      this._needsSort = false;
+    if (this._shouldSort) {
+      this._shouldSort = false;
       this._subviews.sort(compareZOrder);
     }
     var subviews = [];
@@ -142,7 +143,7 @@ exports = class extends BaseBacking {
     backing._addedAt = ++ADD_COUNTER;
 
     if (n && compareZOrder(backing, this._subviews[n - 1]) < 0) {
-      this._needsSort = true;
+      this._shouldSort = true;
     }
 
     if (backing._hasTick || backing._subviewsWithTicks !== null) {
@@ -180,7 +181,7 @@ exports = class extends BaseBacking {
 
   addVisibleSubview (backing) {
     this._visibleSubviews.push(backing);
-    this._visiblesNeedsSort = true;
+    this._shouldSortVisibleSubviews = true;
   }
 
   removeVisibleSubview (backing) {
@@ -260,8 +261,8 @@ exports = class extends BaseBacking {
   }
 
   wrapRender (ctx) {
-    if (this._visiblesNeedsSort) {
-      this._visiblesNeedsSort = false;
+    if (this._shouldSortVisibleSubviews) {
+      this._shouldSortVisibleSubviews = false;
       this._visibleSubviews.sort(compareZOrder);
     }
 
@@ -301,7 +302,9 @@ exports = class extends BaseBacking {
       ctx.fillRect(0, 0, width, height);
     }
 
-    this._view._render && this._view._render(ctx);
+    if (this._hasRender) {
+      this._view._render(ctx);
+    }
     
     var subviews = this._visibleSubviews;
     for (var i = 0; i < subviews.length; i++) {
@@ -332,8 +335,8 @@ exports = class extends BaseBacking {
 
     var superview = this._view.getSuperview();
     if (superview) {
-      superview.__view._needsSort = true;
-      superview.__view._visiblesNeedsSort = true;
+      superview.__view._shouldSort = true;
+      superview.__view._shouldSortVisibleSubviews = true;
     }
   }
 

--- a/src/ui/backend/canvas/ViewBacking.js
+++ b/src/ui/backend/canvas/ViewBacking.js
@@ -20,47 +20,48 @@ let exports = {};
  *
  * Models the style object of the canvas View.
  */
-import strPad from '../strPad';
 import BaseBacking from '../BaseBacking';
+import Matrix2D from '../../../platforms/browser/webgl/Matrix2D';
 
-var IDENTITY_MATRIX = {
-  a: 1,
-  b: 0,
-  c: 0,
-  d: 1,
-  tx: 0,
-  ty: 0
-};
+var IDENTITY_MATRIX = new Matrix2D();
 var sin = Math.sin;
 var cos = Math.cos;
 
 var ADD_COUNTER = 900000;
+
+function compareZOrder (a, b) {
+  var zIndexCmp = a._zIndex - b._zIndex;
+  if (zIndexCmp !== 0) {
+    return zIndexCmp;
+  }
+
+  return a._addedAt - b._addedAt;
+}
 
 exports = class extends BaseBacking {
 
   constructor (view) {
     super();
 
-    this._globalTransform = {
-      a: 1,
-      b: 0,
-      c: 0,
-      d: 1,
-      tx: 0,
-      ty: 0
-    };
+    this._globalTransform = new Matrix2D();
     this._cachedRotation = 0;
     this._cachedSin = 0;
     this._cachedCos = 1;
     this._globalOpacity = 1;
     this._view = view;
     this._superview = null;
+
+    this._needsSort = false;
+    this._visiblesNeedsSort = false;
+
     this._subviews = [];
-    this._childCount = 0;
+    this._visibleSubviews = [];
 
     // number of direct or indirect tick methods
     this._hasTick = !!view._tick;
     this._subviewsWithTicks = null;
+
+    this._addedAt = 0;
   }
 
   getSuperview () {
@@ -70,7 +71,7 @@ exports = class extends BaseBacking {
   getSubviews () {
     if (this._needsSort) {
       this._needsSort = false;
-      this._subviews.sort();
+      this._subviews.sort(compareZOrder);
     }
     var subviews = [];
     var backings = this._subviews;
@@ -138,10 +139,9 @@ exports = class extends BaseBacking {
     this._subviews[n] = backing;
 
     backing._superview = this._view;
-    backing._setAddedAt(++ADD_COUNTER);
-    this._childCount++;
+    backing._addedAt = ++ADD_COUNTER;
 
-    if (n && backing.__sortKey < this._subviews[n - 1].__sortKey) {
+    if (n && compareZOrder(backing, this._subviews[n - 1]) < 0) {
       this._needsSort = true;
     }
 
@@ -149,11 +149,19 @@ exports = class extends BaseBacking {
       this.addTickingView(backing);
     }
 
+    if (backing._visible) {
+      this.addVisibleSubview(backing);
+    }
+
     return true;
   }
 
   removeSubview (view) {
     var backing = view.__view;
+    if (backing._visible) {
+      this.removeVisibleSubview(backing);
+    }
+
     var index = this._subviews.indexOf(backing);
     if (index !== -1) {
       if (backing._hasTick || backing._subviewsWithTicks !== null) {
@@ -161,7 +169,6 @@ exports = class extends BaseBacking {
       }
 
       this._subviews.splice(index, 1);
-      this._childCount--;
 
       // this._view.needsRepaint();
       backing._superview = null;
@@ -169,6 +176,18 @@ exports = class extends BaseBacking {
     }
 
     return false;
+  }
+
+  addVisibleSubview (backing) {
+    this._visibleSubviews.push(backing);
+    this._visiblesNeedsSort = true;
+  }
+
+  removeVisibleSubview (backing) {
+    var index = this._visibleSubviews.indexOf(backing);
+    if (index !== -1) {
+      this._visibleSubviews.splice(index, 1);
+    }
   }
 
   wrapTick (dt, app) {
@@ -240,14 +259,10 @@ exports = class extends BaseBacking {
     }
   }
 
-  wrapRender (ctx, opts) {
-    if (!this.visible) {
-      return;
-    }
-
-    if (this._needsSort) {
-      this._needsSort = false;
-      this._subviews.sort();
+  wrapRender (ctx) {
+    if (this._visiblesNeedsSort) {
+      this._visiblesNeedsSort = false;
+      this._visibleSubviews.sort(compareZOrder);
     }
 
     var width = this._width;
@@ -286,21 +301,17 @@ exports = class extends BaseBacking {
       ctx.fillRect(0, 0, width, height);
     }
 
-    var viewport = opts.viewport;
-    this._view._render && this._view._render(ctx, opts);
-    this._renderSubviews(ctx, opts);
-    opts.viewport = viewport;
+    this._view._render && this._view._render(ctx);
+    
+    var subviews = this._visibleSubviews;
+    for (var i = 0; i < subviews.length; i++) {
+      subviews[i].wrapRender(ctx);
+    }
+
     ctx.clearFilter();
 
     if (saveContext) {
       ctx.restore();
-    }
-  }
-
-  _renderSubviews (ctx, opts) {
-    var subviews = this._subviews;
-    for (var i = 0; i < this._childCount; i++) {
-      subviews[i].wrapRender(ctx, opts);
     }
   }
 
@@ -316,25 +327,26 @@ exports = class extends BaseBacking {
     }
   }
 
-  _onZIndex (_, zIndex) {
-    this._sortIndex = strPad.pad(zIndex);
-
-    this._setSortKey();
+  _onZIndex () {
     this._view.needsRepaint();
 
     var superview = this._view.getSuperview();
     if (superview) {
       superview.__view._needsSort = true;
+      superview.__view._visiblesNeedsSort = true;
     }
   }
 
-  _setAddedAt (addedAt) {
-    this._addedAt = addedAt;
-    this._setSortKey();
-  }
+  _onVisible () {
+    if (this._superview === null) {
+      return;
+    }
 
-  _setSortKey () {
-    this.__sortKey = this._sortIndex + this._addedAt;
+    if (this._visible) {
+      this._superview.__view.addVisibleSubview(this);
+    } else {
+      this._superview.__view.removeVisibleSubview(this);
+    }
   }
 
   _onOffsetX (n) {
@@ -345,13 +357,8 @@ exports = class extends BaseBacking {
     this.offsetY = n * this.height / 100;
   }
 
-  toString () {
-    return this.__sortKey;
-  }
-
 };
 
-exports.prototype._sortIndex = strPad.initialValue;
 var ViewBacking = exports;
 
 export default exports;

--- a/src/ui/backend/dom/ImageView.js
+++ b/src/ui/backend/dom/ImageView.js
@@ -154,7 +154,7 @@ exports = class extends View {
 
     return el;
   }
-  _canvasRender (ctx, opts) {
+  _canvasRender (ctx) {
     var canvas = this._img.getSource();
     ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, this.style
       .width, this.style.height);


### PR DESCRIPTION
## Why
The `wrapRender` method could become de-optimized after a playing for a while.
Also the method was called for many invisible views (ineffective calls to the method).
The idea was to try to stop the de-optimization from happening and improving the subview system to make sure that invisible views wouldn't create overhead in the rendering pipeline.
A few other implementation details surrounding the `wrapRender` method could be fixed.

## How
- By adding a list of visible views to `BaseBacking` it was possible to remove the overhead of invisible classes. These visible views are still ordered in the same way, i.e with respect to z-index first and then added order.
- The `_renderSubviews` method has been removed.
- Some attributes that were added to instances of `BaseBacking` after instantiation time were removed, such as the `_sortKey`.
- The `_addedAt` method is now initialized in the constructor to make sure that all the hidden classes that go through the `wrapRender` method contain it (<= goal is to limit the number of different hidden classes going through the `wrapRender` method).
- The `opts` of the `wrapRender` method has been removed. It was apparently used only by the `ScrollView` in order to communicate viewport information. This viewport information now only exists locally in the `ScrollView`.
- The sort method now take a comparison method as opposed to sorting views based on their stringified sorted keys.

## Result

###  Chrome (macbook) profiling
Before
<img width="393" alt="chrome-before" src="https://user-images.githubusercontent.com/1897225/27128785-f88b4a80-513a-11e7-955f-647e8995e7f2.png">
After
<img width="394" alt="chrome-after" src="https://user-images.githubusercontent.com/1897225/27128792-fdf68f66-513a-11e7-857c-f431e185d750.png">

The `wrapRender` method in itself went from number 1 to number 2. The `_renderSubviews` method has now completely disappeared. They accounted for 16.5% of the resources before the refactoring down to 9% after.


###  Safari (iPhone 7) profiling
Before
<img width="368" alt="screen shot 2017-06-14 at 4 10 49 pm" src="https://user-images.githubusercontent.com/1897225/27128936-7b0bda9c-513b-11e7-8fcb-6158941ffb84.png">

After
<img width="367" alt="screen shot 2017-06-14 at 4 07 10 pm" src="https://user-images.githubusercontent.com/1897225/27128929-744ef9c8-513b-11e7-81b4-cd452924f846.png">

The `wrapTick` + `_renderSubviews` method went from ~11% to 6%.

### Chrome (macbook) measure
The measurements of the Engine's `tick` also are showing good improvements
Before
<img width="277" alt="screen shot 2017-06-13 at 1 45 03 pm" src="https://user-images.githubusercontent.com/1897225/27066453-4cf2828e-503f-11e7-895a-4ce240019946.png">

After
<img width="271" alt="screen shot 2017-06-14 at 7 15 09 pm" src="https://user-images.githubusercontent.com/1897225/27129057-f8d5fef8-513b-11e7-99ae-304e133b8488.png">


The FPS in gameplay phase on Xperia Z3 seems to be higher, now in the 50~60fps range in light gameplay.

The gameplay benchmark shows an non-idle time of 11.64%, down from 13.5%! (still on my machine)
Overall it looks like another ~10% CPU gain.

### Sorting
The new sorting seems to give better performance. To test it I enforced the sort to happen every frame for every view:
Before
<img width="637" alt="screen shot 2017-06-14 at 7 01 49 pm" src="https://user-images.githubusercontent.com/1897225/27133920-d49bfef8-514e-11e7-86fd-cd118208632c.png">

After
<img width="639" alt="screen shot 2017-06-14 at 7 05 21 pm" src="https://user-images.githubusercontent.com/1897225/27133925-db5b0eb4-514e-11e7-9be3-9dfb477ad279.png">

Total time taken by the sorting is down from 10% to 4%. Conclusion: using a comparison method for sorting appears more efficient than sorting elements as strings. Of course the in-game benefit is smaller but considering the sorting now happens more often I thought it  might be best to optimize the sorting.

**Note:** Refactoring of dom ViewBacking not tested!