### PR TITLE
Fixed bad layout initialization

### DIFF
--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -267,6 +267,10 @@ export default class View extends IView {
       this._infinite = opts.infinite;
     }
 
+    if (opts.layout) {
+      this.__view.layout = opts.layout;
+    }
+
     this.style.update(opts);
     this.__input.update(opts);
 

--- a/src/ui/layout/BoxLayout.js
+++ b/src/ui/layout/BoxLayout.js
@@ -199,7 +199,7 @@ export default class BoxLayout {
         s.y = Math.round((availHeight - s.scale * h) / 2 + (padding &&
           padding.top || 0));
       }
-      if (h !== undefined && s.top == undefined && s.bottom != undefined) {
+      if (h !== undefined && s.top === undefined && s.bottom !== undefined) {
         s.y = Math.round(availHeight - s.scale * h - s.bottom - (padding &&
           padding.bottom || 0));
       }

--- a/src/ui/layout/LayoutViewBacking.js
+++ b/src/ui/layout/LayoutViewBacking.js
@@ -26,7 +26,7 @@ export default class LayoutViewBacking extends ViewBacking {
     super(view);
 
     this._order = 0;
-    this._direction = false;
+    this._direction = 'vertical';
     this._flex = 0;
     this._justifyContent = 'start';
     this._centerX = false;
@@ -45,8 +45,8 @@ export default class LayoutViewBacking extends ViewBacking {
     this._layoutWidth = undefined;
     this._layoutHeight = undefined;
 
+    this._padding = undefined;
     this._margin = null;
-    this._padding = null;
 
     this._sortOrder = strPad.initialValue;
 
@@ -245,6 +245,27 @@ export default class LayoutViewBacking extends ViewBacking {
     copy.layoutHeightIsPercent = this._layoutHeightIsPercent;
 
     return copy;
+  }
+
+  update (style) {
+    // updating properties that are initialized as undefined
+    // they need to be checked manually
+    if (style.top) { this.top = style.top; }
+    if (style.right) { this.right = style.right; }
+    if (style.bottom) { this.bottom = style.bottom; }
+    if (style.left) { this.left = style.left; }
+
+    if (style.minWidth) { this.minWidth = style.minWidth; }
+    if (style.minHeight) { this.minHeight = style.minHeight; }
+    if (style.maxWidth) { this.maxWidth = style.maxWidth; }
+    if (style.maxHeight) { this.maxHeight = style.maxHeight; }
+
+    if (style.layoutWidth) { this.layoutWidth = style.layoutWidth; }
+    if (style.layoutHeight) { this.layoutHeight = style.layoutHeight; }
+
+    if (style.padding) { this.padding = style.padding; }
+
+    return super.update(style);
   }
 
   _onOrder () {

--- a/src/ui/layout/LayoutViewBacking.js
+++ b/src/ui/layout/LayoutViewBacking.js
@@ -248,24 +248,26 @@ export default class LayoutViewBacking extends ViewBacking {
   }
 
   update (style) {
+    super.update(style)
+
     // updating properties that are initialized as undefined
     // they need to be checked manually
-    if (style.top) { this.top = style.top; }
-    if (style.right) { this.right = style.right; }
-    if (style.bottom) { this.bottom = style.bottom; }
-    if (style.left) { this.left = style.left; }
+    if (style.top !== undefined) { this.top = style.top; }
+    if (style.right !== undefined) { this.right = style.right; }
+    if (style.bottom !== undefined) { this.bottom = style.bottom; }
+    if (style.left !== undefined) { this.left = style.left; }
 
-    if (style.minWidth) { this.minWidth = style.minWidth; }
-    if (style.minHeight) { this.minHeight = style.minHeight; }
-    if (style.maxWidth) { this.maxWidth = style.maxWidth; }
-    if (style.maxHeight) { this.maxHeight = style.maxHeight; }
+    if (style.minWidth !== undefined) { this.minWidth = style.minWidth; }
+    if (style.minHeight !== undefined) { this.minHeight = style.minHeight; }
+    if (style.maxWidth !== undefined) { this.maxWidth = style.maxWidth; }
+    if (style.maxHeight !== undefined) { this.maxHeight = style.maxHeight; }
 
-    if (style.layoutWidth) { this.layoutWidth = style.layoutWidth; }
-    if (style.layoutHeight) { this.layoutHeight = style.layoutHeight; }
+    if (style.layoutWidth !== undefined) { this.layoutWidth = style.layoutWidth; }
+    if (style.layoutHeight !== undefined) { this.layoutHeight = style.layoutHeight; }
 
-    if (style.padding) { this.padding = style.padding; }
+    if (style.padding !== undefined) { this.padding = style.padding; }
 
-    return super.update(style);
+    return this;
   }
 
   _onOrder () {

--- a/src/ui/layout/LinearLayout.js
+++ b/src/ui/layout/LinearLayout.js
@@ -196,7 +196,7 @@ export default class LinearLayout extends BoxLayout {
   }
 
   insertBefore (view, before) {
-    if (this.getViewIndex(view) != -1) {
+    if (this.getViewIndex(view) !== -1) {
       return;
     }
 
@@ -218,7 +218,7 @@ export default class LinearLayout extends BoxLayout {
   }
 
   insertAfter (view, after) {
-    if (this.getViewIndex(view) != -1) {
+    if (this.getViewIndex(view) !== -1) {
       return;
     }
 
@@ -268,11 +268,11 @@ export default class LinearLayout extends BoxLayout {
     this._views.sort();
 
     var layoutStyle = this._view.style;
-    if (layoutStyle.direction != this._direction) {
+    if (layoutStyle.direction !== this._direction) {
       this._setDirection(layoutStyle.direction);
     }
 
-    var isVertical = this._direction == 'vertical';
+    var isVertical = this._direction === 'vertical';
     var propDim = this._propDim;
     var propDimOpp = this._propDimOpp;
     var minPropDim = this._minPropDim;
@@ -309,7 +309,7 @@ export default class LinearLayout extends BoxLayout {
       }
     }
 
-    if (flexSum && parentDim == undefined) {
+    if (flexSum && parentDim === undefined) {
       return;
     }
 
@@ -405,9 +405,9 @@ export default class LinearLayout extends BoxLayout {
 
     this._debug && this._summarize() && _debug.stepOut();
 
-    if (isVertical && layoutStyle.layoutHeight == 'wrapContent') {
+    if (isVertical && layoutStyle.layoutHeight === 'wrapContent') {
       this.reflowY();
-    } else if (!isVertical && layoutStyle.layoutWidth == 'wrapContent') {
+    } else if (!isVertical && layoutStyle.layoutWidth === 'wrapContent') {
       this.reflowX();
     }
 


### PR DESCRIPTION
Also fixed issue where updating the laying through the `updateOpts` method would not have the desired effect.

Tested on Puzzle bubble blitz and Everwing but would be better if game devs could double check!
(could not test Cats due to incompatibility with `MovieClip` version -> work in progress)

**Note:** I did not rerun perf benchmarks but I would not imagine this changes to have a measurable impact.

I realized that there might be a better way to refactor the layout extension: by having a `Layout` class with all those layout properties and have `BoxLayout` inherit from it. The only issue is that those properties should be settable through the style, therefore the `ViewBacking` should act as a proxy. This solution might actually be best for performance and also a step toward changing the layout API if we wanted to (my opinion is that the layout properties should not be set through the style and rather be a separate entity).