### PR TITLE
MovieClip

### DIFF
--- a/src/movieclip/AnimationData.js
+++ b/src/movieclip/AnimationData.js
@@ -1,0 +1,341 @@
+import { CACHE } from 'base';
+import Promise from 'bluebird';
+import loader from 'ui/resource/loader';
+import Rect from 'math/geom/Rect';
+import Matrix from 'platforms/browser/webgl/Matrix2D';
+import ImageViewCache from 'ui/resource/ImageViewCache';
+
+const NULL_ANIMATION = '__none';
+
+// -----------------------------------
+// AnimationData
+// -----------------------------------
+
+export default class AnimationData {
+
+  constructor (data) {
+    this.url = data.url;
+    this.frameRate = data.frameRate;
+    // this.skins = data.skins;
+    if (data.skins && Object.keys(data.skins).length > 0) {
+      console.error('HANDLE SKINS!!')
+    }
+
+    // TODO: simplify export format by combining skins, symbols, ids and sprites
+    // into a single library map object in reverse hierarchical order
+    // for faster data generation
+
+    var ids = data.ids;
+    var elementCount = Matrix.ELEMENT_COUNT;
+    var transformsBuffer = data.transforms;
+    var transformCount = transformsBuffer.length / elementCount;
+
+    var transforms = new Array(transformCount);
+
+    for (var t = 0; t < transformCount; t++) {
+      var id = t * elementCount;
+      var transform = transforms[t] = new Matrix();
+      transform.a = transformsBuffer[id];
+      transform.b = transformsBuffer[id + 1];
+      transform.c = transformsBuffer[id + 2];
+      transform.d = transformsBuffer[id + 3];
+      transform.tx = transformsBuffer[id + 4];
+      transform.ty = transformsBuffer[id + 5];
+    }
+
+    var symbols = data.animations;
+    this.symbolList = Object.keys(symbols);
+
+    this.library = {};
+    // TODO: remove these properties, is used in Cats PropView & CatView
+    this.animations = this.library;
+    this.animationList = this.symbolList;
+
+    // reference to all instances
+    // used to setup quick access to library elements
+    var allInstances = [];
+
+    // populating library with symbols
+    for (var s = 0; s < this.symbolList.length; s += 1) {
+      var symbolID = this.symbolList[s];
+      var frames = symbols[symbolID];
+
+      var timeline = [];
+      for (var f = 0; f < frames.length; f += 1) {
+        var instancesData = frames[f];
+        var instances = timeline[f] = [];
+        for (var i = 0; i < instancesData.length; i += 1) {
+          var instanceData = instancesData[i];
+          var transform = transforms[instanceData[0]];
+          // var instanceType = instanceData[1]; // TODO: remove type info from export data
+          var libraryID = ids[instanceData[2]];
+          var frame = instanceData[3];
+          var alpha = instanceData[4];
+
+          var instance = new Instance(libraryID, frame, transform, alpha);
+          instances.push(instance);
+          allInstances.push(instance);
+        }
+      }
+
+      this.library[symbolID] = new Symbol(timeline);
+    }
+
+    // adding a null animation to the library
+    var emptyTimeline = [[]]; 
+    this.library[NULL_ANIMATION] = new Symbol(emptyTimeline);
+
+    // populating library with sprites
+    var spritesData = data.textureOffsets;
+    for (var spriteID in spritesData) {
+      var spriteData = spritesData[spriteID];
+      var image = ImageViewCache.getImage(this.url + '/' + spriteData.url);
+      this.library[spriteID] = new Sprite(image, spriteData);
+    }
+
+    for (var i = 0; i < allInstances.length; i += 1) {
+      allInstances[i].linkElement(this.library);
+    }
+  }
+
+}
+
+
+// -----------------------------------
+// AnimationData Loader
+// -----------------------------------
+
+const animationDataCache = {};
+const loadCallbacks = {};
+
+AnimationData.loadFromURL = function (url) {
+  var data = animationDataCache[url];
+
+  if (data) {
+    return Promise.resolve(data);
+  }
+
+  var fullPath = url + '/data.js';
+  var dataString = CACHE[fullPath];
+
+  if (dataString) {
+    var rawData = JSON.parse(dataString);
+    rawData.url = url;
+    data = animationDataCache[url] = new AnimationData(rawData);
+    return Promise.resolve(data);
+  }
+
+  return new Promise((resolve, reject) => {
+
+    if (loadCallbacks[url]) {
+      loadCallbacks[url].push({ resolve, reject });
+      return;
+    }
+
+    loadCallbacks[url] = [ { resolve, reject } ];
+
+    loader.preload(fullPath, () => {
+
+      dataString = CACHE[fullPath];
+
+      if (dataString) {
+        var rawData = JSON.parse(dataString);
+        rawData.url = url;
+        data = animationDataCache[url] = new AnimationData(rawData);
+      }
+
+      var callbacks = loadCallbacks[url];
+
+      for (var i = 0, len = callbacks.length; i < len; i++) {
+        var method = data ? callbacks[i].resolve : callbacks[i].reject;
+        var param = data || new Error('Could not load data.');
+        method(param);
+      }
+
+      // Don't keep around references to callbacks
+      callbacks.length = 0;
+    });
+
+  });
+};
+
+// -----------------------------------
+// Sprite
+// -----------------------------------
+
+class Bounds {
+
+  constructor (boundsData) {
+    this.x = boundsData.x;
+    this.y = boundsData.y;
+    this.width = boundsData.width;
+    this.height = boundsData.height;
+  }
+
+}
+
+class Sprite {
+
+  constructor (image, spriteData) {
+    this.image = image;
+    this.bounds = new Bounds(spriteData);
+  }
+
+  _rendeFrame (ctx, transform, alpha) {
+    ctx.setTransform(transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
+    ctx.globalAlpha = alpha;
+
+    var bounds = this.bounds;
+    this.image.renderShort(ctx, bounds.x, bounds.y, bounds.width, bounds.height);
+  }
+
+  expandBoundingBox (boundingBox, transform) {
+    var left = this.bounds.x;
+    var right = this.bounds.x + this.bounds.width;
+    var top = this.bounds.y;
+    var bottom = this.bounds.y + this.bounds.height;
+
+    var a = transform.a;
+    var b = transform.b;
+    var c = transform.c;
+    var d = transform.d;
+    var tx = transform.tx;
+    var ty = transform.ty;
+
+    var x0 = left * a + top * c + tx;
+    var y0 = left * b + top * d + ty;
+    var x1 = right * a + top * c + tx;
+    var y1 = right * b + top * d + ty;
+    var x2 = left * a + bottom * c + tx;
+    var y2 = left * b + bottom * d + ty;
+    var x3 = right * a + bottom * c + tx;
+    var y3 = right * b + bottom * d + ty;
+
+    boundingBox.left = Math.min(boundingBox.left, x0, x1, x2, x3);
+    boundingBox.top = Math.min(boundingBox.top, y0, y1, y2, y3);
+
+    boundingBox.right = Math.max(boundingBox.right, x0, x1, x2, x3);
+    boundingBox.bottom = Math.max(boundingBox.bottom, y0, y1, y2, y3);
+  }
+
+}
+
+
+// -----------------------------------
+// Symbol
+// -----------------------------------
+
+class Symbol {
+
+  constructor (timeline) {
+    this.timeline = timeline;
+    this.duration = timeline.length;
+
+    this.transform = new Matrix();
+  }
+
+  _rendeFrame (ctx, parentTransform, parentAlpha, instance, substitutes /*, deltaFrame */) {
+    var frame = instance.getFrame(this.duration);
+
+    var children = this.timeline[frame];
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i];
+
+      var alpha = parentAlpha * child.alpha;
+      var transform = this.transform;
+      transform.copy(parentTransform);
+      transform.transform(child.transform);
+
+      // n.b element can be of 3 different types: Symnbol, Sprite or FlashPlayerView
+      // therefore this method cannot be perfectly optimized by optimizer-compilers
+      // also, the lookup in the substitutes map is slow
+      var element = substitutes[child.libraryID] || child.element;
+      element._rendeFrame(ctx, transform, alpha, child, substitutes);
+    }
+  }
+
+  expandBoundingBox (boundingBox, parentTransform, instance, substitutes /*, deltaFrame */) {
+    // TODO: if instance is movie clip, the bounds should include all its frames
+    var frame = instance.getFrame(this.duration /*, deltaFrame */);
+
+    var children = this.timeline[frame];
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i];
+      if (child.alpha === 0) {
+        // No need to expand bounds to include invisible elements
+        continue;
+      }
+
+      var transform = this.transform;
+      transform.copy(parentTransform);
+      transform.transform(child.transform);
+
+      var element = substitutes[child.libraryID] || child.element;
+      element.expandBoundingBox(boundingBox, transform, child, substitutes /*, deltaFrame */);
+    }
+  }
+
+}
+
+// -----------------------------------
+// Instance
+// -----------------------------------
+
+class Instance {
+
+  constructor (libraryID, frame, transform, alpha) {
+    // TODO: support all types of identifications
+    this.libraryID = libraryID; // id of instantiated element in the library
+    // this.instanceName = instanceName; // Optional, only movie clips can have it
+    // this.className = className; // Optinal, aka ActionScript linkage
+
+    this.frame = frame;
+    this.transform = transform;
+    this.alpha = alpha;
+    // TODO: replace alpha with full color transform
+    // this.colorTransform = null;
+
+    this.element = null;
+
+    // TODO: Handle movie clips (non-graphics)
+    // this.isGraphic = true;
+    // TODO: Handle graphic playing options
+    // this.singleFrame = false;
+    // this.firstFrame = 0;
+    // this.loop = true;
+  }
+
+  linkElement (library) {
+    this.element = library[this.libraryID];
+  }
+
+  getFrame (duration /*, deltaFrame */) {
+    if (this.frame >= duration) {
+      return this.frame % duration;
+    }
+
+    return this.frame;
+    // TODO: Handle all playing options
+    // if (this.isGraphic) {
+    //   if (this.singleFrame) {
+    //     return this.firstFrame;
+    //   }
+
+    //   var frame = this.firstFrame + this.frame;
+    //   if (frame >= duration) {
+    //     return this.loop ? frame % duration : duration;
+    //   }
+
+    //   return frame;
+    // }
+
+    // this.frame += deltaFrame;
+    // if (this.frame >= duration) {
+    //   this.frame = this.frame % duration;
+    // }
+    // return this.frame;
+  }
+
+}
+
+AnimationData.Instance = Instance;

--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -112,6 +112,26 @@ export default class MovieClip extends View {
     }
   }
 
+  updateOpts (opts) {
+    super.updateOpts(opts);
+
+    if (!opts) {
+      return;
+    }
+
+    if (opts.fps !== undefined) {
+      this.fps = opts.fps;
+    }
+
+    if (opts.url !== undefined) {
+      this.url = opts.url;
+    }
+
+    if (opts.buffered !== undefined) {
+      this.buffered = !!opts.buffered;
+    }
+  }
+
   goto (frameIndex) {
     if (this.frameCount === 0) { return; }
     this.frame = frameIndex % this.frameCount;
@@ -361,10 +381,10 @@ export default class MovieClip extends View {
     return this._buffered;
   }
 
-  set buffered (value) {
-    if (this._buffered === value) { return; }
+  set buffered (buffered) {
+    if (this._buffered === buffered) { return; }
 
-    this._buffered = value;
+    this._buffered = buffered;
     this._frameDirty = true;
 
     if (this.buffered) {
@@ -384,9 +404,9 @@ export default class MovieClip extends View {
     return this._fps;
   }
 
-  set fps (value) {
-    this._fps = value;
-    this._frameMS = 1000 / value;
+  set fps (fps) {
+    this._fps = fps;
+    this._frameMS = 1000 / fps;
   }
 
   get loaded () {
@@ -397,19 +417,19 @@ export default class MovieClip extends View {
     return this._url;
   }
 
-  set url (value) {
-    if (this._url === value) {
+  set url (url) {
+    if (this._url === url) {
       return;
     }
 
-    this._url = value;
+    this._url = url;
 
-    if (!value) { return; }
+    if (!url) { return; }
 
     AnimationData
-      .loadFromURL(value)
+      .loadFromURL(url)
       .then(data => {
-        if (this._url === value) {
+        if (this._url === url) {
           this.setData(data);
         }
       });

--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -1,0 +1,417 @@
+
+import device from 'device';
+import Rect from 'math/geom/Rect';
+import View from 'ui/View';
+
+import Matrix from 'platforms/browser/webgl/Matrix2D';
+
+import AnimationData from './AnimationData';
+
+/* TERMINOLOGY
+ *
+ * Sprite: an image or a rasterized Flash vectorial shape.
+ *   Corresponds to an Image object in this implementation.
+ *
+ * Element: an object equivalent to a Flash element (can be a Sprite or a Symbol)
+ *
+ * Library: a list of elements.
+ *
+ * Instance: an element with a particular state (position, color, filter, etc...).
+ *
+ * Timeline: a list of instances and their frame indexes.
+ *
+ * Symbol: an element that has a timeline.
+ *
+ * MovieClip: an instance of a Symbol within a timeline
+ *   whose frame is independent from the frame of the timeline it belongs to.
+ *
+ * Graphic: an instance of a Symbol within a timeline
+ *   whose frame is dependent from the frame of the timeline it belongs to.
+ *
+ * FlashPlayerView: an object that exposes an API to load and play Flash animations.
+ *   It has a library, an FPS and a set of API to control and combine Flash animations data.
+ *   It also inherits from a timestep View and be handled as such.
+ *
+ */
+
+class BBox {
+
+  constructor () {
+    this.reset();
+  }
+
+  reset () {
+    this.left = Infinity;
+    this.top = Infinity;
+    this.right = -Infinity;
+    this.bottom = -Infinity;
+  }
+
+}
+
+var Instance = AnimationData.Instance;
+
+const Canvas = device.get('Canvas');
+const canvasPool = [];
+
+const IDENTITY_MATRIX = new Matrix();
+const NULL_BOUNDS = new Rect();
+
+var viewCount = 0;
+var EMPTY = {};
+
+// TODO: rename file to FlashPlayerView
+export default class FlashPlayerView extends View {
+
+  constructor (opts) {
+    super(opts);
+
+    opts = opts || EMPTY;
+
+    this.id = viewCount++;
+
+    this._elapsed = 0;
+
+    this.frame = 0;
+    this.framesElapsed = 0;
+    this.looping = false;
+    this.frameCount = 0;
+    this.isPlaying = false;
+    this._animationName = '';
+    this._instance = new Instance('', 0, IDENTITY_MATRIX, 1);
+
+    this._callback = null;
+    this._boundsMap = {};
+
+    this._canvas = null;
+    this._ctx = null;
+    this._frameDirty = true;
+
+    this._library = null;
+    this._substitutes = {};
+
+    this.animation = null;
+    this.timeline = null;
+
+    this._bounds = new Rect();
+    this._bbox = new BBox();
+    this._transform = new Matrix();
+
+    this._nbViewSubstitutions = 0;
+
+    this.fps = opts.fps ? opts.fps : 30;
+    this.url = opts.url ? opts.url : null;
+    this.data = opts.data ? opts.data : null;
+    this.buffered = opts.buffered ? opts.buffered : null;
+
+    if (this.data && opts.defaultAnimation) {
+      this.loop(opts.defaultAnimation);
+    }
+  }
+
+  goto (frameIndex) {
+    if (this.frameCount === 0) { return; }
+    this.frame = frameIndex % this.frameCount;
+    this.framesElapsed = frameIndex;
+  }
+
+  render (ctx) {
+    if (!this.animation) {
+      return;
+    }
+
+    if (this._buffered && this._nbViewSubstitutions === 0) {
+      // Update and render internal canvas to context
+      var bounds = this.getBounds();
+      if (bounds === NULL_BOUNDS) {
+        return;
+      }
+
+      if (this._frameDirty) {
+        this.updateCanvasBounds(bounds);
+        this._ctx.clear();
+        this._transform.setTo(1, 0, 0, 1, -bounds.x, -bounds.y);
+        this.animation._rendeFrame(this._ctx, this._transform, 1, this._instance, this._substitutes /*, deltaFrame */);
+        this._frameDirty = false;
+      }
+
+      ctx.drawImage(this._canvas, 0, 0, bounds.width, bounds.height, bounds.x, bounds.y, bounds.width, bounds.height);
+    } else {
+      // Render directly to context
+      this._transform.copy(ctx.getTransform());
+      this.animation._rendeFrame(ctx, this._transform, ctx.globalAlpha, this._instance, this._substitutes /*, deltaFrame */);
+    }
+  }
+
+  _rendeFrame (ctx, parentTransform, parentOpacity) {
+    this.style.wrapRender(ctx, parentTransform, parentOpacity);
+  }
+
+  getBounds (elementID) {
+    if (!this.loaded) {
+      return NULL_BOUNDS;
+    }
+
+    if (!elementID) {
+      var animationBounds = this._boundsMap[this._animationName];
+      if (animationBounds) {
+        return animationBounds;
+      }
+
+      elementID = this._animationName;
+    }
+
+    var animation = this._substitutes[elementID] || this._library[elementID];
+    if (!animation || animation.animation === null) {
+      return NULL_BOUNDS;
+    }
+
+    var bounds = new Rect(0, 0, Infinity, Infinity);
+    if (elementID === this._animationName) {
+      this._boundsMap[this._animationName] = bounds;
+    }
+
+    this.updateBoundingBox(animation, IDENTITY_MATRIX);
+
+    bounds.x = Math.floor(this._bbox.left);
+    bounds.y = Math.floor(this._bbox.top);
+    bounds.width = Math.ceil(this._bbox.right - this._bbox.left);
+    bounds.height = Math.ceil(this._bbox.bottom - this._bbox.top);
+
+    // TODO: bounds with negative dimensions should be compatible with timestep engine
+    if (bounds.width === -Infinity) { bounds.width = 0; }
+    if (bounds.height === -Infinity) { bounds.height = 0; }
+
+    return bounds;
+  }
+
+  updateBoundingBox (animation, transform) {
+    this._bbox.reset();
+
+    var actualFrame = this.frame;
+    var timeline = animation.timeline;
+    for (var frame = 0; frame < timeline.length; frame++) {
+      this._instance.frame = frame;
+      animation.expandBoundingBox(this._bbox, transform, this._instance, this._substitutes);
+    }
+
+    this._instance.frame = actualFrame;
+  }
+
+  expandBoundingBox (boundingBox, transform, child, substitutes) {
+    if (!this.animation) {
+      return;
+    }
+
+    this.updateBoundingBox(this.animation, transform);
+    boundingBox.left = Math.min(this._bbox.left, boundingBox.left);
+    boundingBox.top = Math.min(this._bbox.top, boundingBox.top);
+    boundingBox.right = Math.max(this._bbox.right, boundingBox.right);
+    boundingBox.bottom = Math.max(this._bbox.bottom, boundingBox.left);
+  }
+
+  clearBoundsMap () {
+    this._boundsMap = {};
+  }
+
+  play (animationName, callback, loop) {
+    if (!this.data) {
+      this.once(FlashPlayerView.LOADED, () => {
+        this.play(animationName, callback, loop)
+      });
+      return;
+    }
+
+    this._frameDirty = animationName !== this._animationName;
+    this._animationName = animationName;
+    this._instance.libraryID = animationName;
+    this._instance.frame = 0;
+    this.looping = loop || false;
+    this.isPlaying = true;
+    this.animation = this._library[animationName];
+    this.timeline = this.animation.timeline;
+    this.frameCount = this.animation.duration;
+    this.frame = 0;
+    this.framesElapsed = 0;
+    this._callback = callback || null;
+  }
+
+  loop (animationName) {
+    this.play(animationName, null, true);
+  }
+
+  stop () {
+    this.isPlaying = false;
+  }
+
+  tick (dt) {
+    if (!this.animation || !this.isPlaying) {
+      return;
+    }
+
+    this._elapsed += dt;
+
+    var currentFrame = this.frame;
+
+    while (this._elapsed > this._frameMS) {
+      this.frame++;
+      this.framesElapsed++;
+      this._elapsed -= this._frameMS;
+    }
+
+    if (this.frame >= this.frameCount) {
+      if (this.looping) {
+        this.frame = this.frame % this.animation.duration;
+      } else {
+        this.frame = this.frameCount > 0 ? this.frameCount - 1 : 0;
+        this.stop();
+        if (this._callback) {
+          var callback = this._callback;
+          this._callback = null;
+          callback();
+        }
+      }
+    }
+
+    if (this.frame !== currentFrame) {
+      this._instance.frame = currentFrame;
+      this._frameDirty = true;
+    }
+  }
+
+  updateCanvasBounds (bounds) {
+    var canvasNeedsUpdate = this._buffered && bounds.width > 0 &&
+      (this._canvas.width !== bounds.width || this._canvas.height !== bounds.height);
+
+    if (canvasNeedsUpdate) {
+      this._canvas.width = bounds.width;
+      this._canvas.height = bounds.height;
+    }
+  }
+
+  addViewSubstitution (libraryID, replacement) {
+    this._substitutes[libraryID] = replacement;
+    this._nbViewSubstitutions += 1;
+    this.clearBoundsMap();
+  }
+
+  removeViewSubstitution (libraryID) {
+    if (this._substitutes[libraryID]) {
+      delete this._substitutes[libraryID];
+      this._nbViewSubstitutions -= 1;
+      this.clearBoundsMap();
+    }
+  }
+
+  addAnimationSubstitution (libraryID, newlibraryID, animationData = null, optional = false) {
+    var library = animationData ? animationData.library : this._library;
+    var replacement = library[newlibraryID];
+    if (!optional || replacement) {
+      this._substitutes[libraryID] = replacement;
+      this.clearBoundsMap();
+    }
+  }
+
+  removeAnimationSubstitution (libraryID) {
+    if (this._substitutes[libraryID]) {
+      delete this._substitutes[libraryID];
+      this.clearBoundsMap();
+    }
+  }
+
+  removeAllSubstitutions () {
+    this._substitutes = {};
+    this.clearBoundsMap();
+  }
+
+  addAnimationSubstitutions (libraryIDs, animationData) {
+    var library = animationData.library;
+    for (var i = 0; i < libraryIDs.length; i++) {
+      var libraryID = libraryIDs[i];
+      this._substitutes[libraryID] = library[libraryID];
+    }
+    this.clearBoundsMap();
+  }
+
+  setData (data) {
+    if (this.data === data) { return; }
+
+    if (data) {
+      this.data = data;
+      this.fps = this._opts.fps || this.data.frameRate || 30;
+      this._library = data.library;
+      this.emit(FlashPlayerView.LOADED);
+    } else {
+      this.data = null;
+      this.animation = null;
+    }
+  }
+
+  get buffered () {
+    return this._buffered;
+  }
+
+  set buffered (value) {
+    if (this._buffered === value) { return; }
+
+    this._buffered = value;
+    this._frameDirty = true;
+
+    if (this.buffered) {
+      this._canvas = obtainCanvasFromPool();
+      this._ctx = this._canvas.getContext('2d');
+    } else if (this._canvas) {
+      returnCanvasToPool(this._canvas);
+      this._canvas = this._ctx = null;
+    }
+  }
+
+  get animationList () {
+    return this.data && this.data.symbolList || [];
+  }
+
+  get fps () {
+    return this._fps;
+  }
+
+  set fps (value) {
+    this._fps = value;
+    this._frameMS = 1000 / value;
+  }
+
+  get loaded () {
+    return !!this.data;
+  }
+
+  get url () {
+    return this._url;
+  }
+
+  set url (value) {
+    if (this._url === value) {
+      return;
+    }
+
+    this._url = value;
+
+    if (!value) { return; }
+
+    AnimationData
+      .loadFromURL(value)
+      .then(data => {
+        if (this._url === value) {
+          this.setData(data);
+        }
+      });
+  }
+}
+
+function obtainCanvasFromPool () {
+  return canvasPool.length > 0 ? canvasPool.pop() : new Canvas({ useWebGL: true });
+}
+
+function returnCanvasToPool (canvas) {
+  canvasPool.push(canvas);
+}
+
+FlashPlayerView.LOADED = 'loaded';

--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -102,10 +102,15 @@ export default class MovieClip extends View {
 
     this._nbViewSubstitutions = 0;
 
+    this._url = null;
+
     this.fps = opts.fps ? opts.fps : 30;
-    this.url = opts.url ? opts.url : null;
     this.data = opts.data ? opts.data : null;
     this.buffered = opts.buffered ? opts.buffered : null;
+
+    if (!this.data && opts.url) {
+      this.url = opts.url;
+    }
 
     if (opts.defaultAnimation) {
       this.loop(opts.defaultAnimation);
@@ -136,13 +141,14 @@ export default class MovieClip extends View {
     if (this.frameCount === 0) { return; }
     this.frame = frameIndex % this.frameCount;
     this.framesElapsed = frameIndex;
-    this._instance.frame = this.frame;
   }
 
   render (ctx, transform) {
     if (!this.animation) {
       return;
     }
+
+    this._instance.frame = this.frame;
 
     if (this._buffered && this._nbViewSubstitutions === 0) {
       // Update and render internal canvas to context
@@ -294,7 +300,6 @@ export default class MovieClip extends View {
     }
 
     if (this.frame !== currentFrame) {
-      this._instance.frame = currentFrame;
       this._frameDirty = true;
     }
   }
@@ -369,6 +374,7 @@ export default class MovieClip extends View {
     if (data) {
       this.data = data;
       this.fps = this._opts.fps || this.data.frameRate || 30;
+      this._url = data.url;
       this._library = data.library;
       this.emit(MovieClip.LOADED);
     } else {
@@ -425,6 +431,12 @@ export default class MovieClip extends View {
     this._url = url;
 
     if (!url) { return; }
+
+    var animationData = AnimationData.getAnimation(url);
+    if (animationData) {
+      this.setData(animationData);
+      return;
+    }
 
     AnimationData
       .loadFromURL(url)

--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -28,7 +28,7 @@ import AnimationData from './AnimationData';
  * Graphic: an instance of a Symbol within a timeline
  *   whose frame is dependent from the frame of the timeline it belongs to.
  *
- * FlashPlayerView: an object that exposes an API to load and play Flash animations.
+ * FlashPlayerView (currently named MovieClip): an object that exposes an API to load and play Flash animations.
  *   It has a library, an FPS and a set of API to control and combine Flash animations data.
  *   It also inherits from a timestep View and be handled as such.
  *
@@ -60,8 +60,8 @@ const NULL_BOUNDS = new Rect();
 var viewCount = 0;
 var EMPTY = {};
 
-// TODO: rename file to FlashPlayerView
-export default class FlashPlayerView extends View {
+// TODO: rename to FlashPlayerView
+export default class MovieClip extends View {
 
   constructor (opts) {
     super(opts);
@@ -90,6 +90,9 @@ export default class FlashPlayerView extends View {
     this._library = null;
     this._substitutes = {};
 
+    this._originalTransforms = {};
+    this._currentSkin = null;
+
     this.animation = null;
     this.timeline = null;
 
@@ -104,7 +107,7 @@ export default class FlashPlayerView extends View {
     this.data = opts.data ? opts.data : null;
     this.buffered = opts.buffered ? opts.buffered : null;
 
-    if (this.data && opts.defaultAnimation) {
+    if (opts.defaultAnimation) {
       this.loop(opts.defaultAnimation);
     }
   }
@@ -113,6 +116,7 @@ export default class FlashPlayerView extends View {
     if (this.frameCount === 0) { return; }
     this.frame = frameIndex % this.frameCount;
     this.framesElapsed = frameIndex;
+    this._instance.frame = this.frame;
   }
 
   render (ctx) {
@@ -131,7 +135,7 @@ export default class FlashPlayerView extends View {
         this.updateCanvasBounds(bounds);
         this._ctx.clear();
         this._transform.setTo(1, 0, 0, 1, -bounds.x, -bounds.y);
-        this.animation._rendeFrame(this._ctx, this._transform, 1, this._instance, this._substitutes /*, deltaFrame */);
+        this.animation.rendeFrame(this._ctx, this._transform, 1, this._instance, this._substitutes /*, deltaFrame */);
         this._frameDirty = false;
       }
 
@@ -139,11 +143,11 @@ export default class FlashPlayerView extends View {
     } else {
       // Render directly to context
       this._transform.copy(ctx.getTransform());
-      this.animation._rendeFrame(ctx, this._transform, ctx.globalAlpha, this._instance, this._substitutes /*, deltaFrame */);
+      this.animation.rendeFrame(ctx, this._transform, ctx.globalAlpha, this._instance, this._substitutes /*, deltaFrame */);
     }
   }
 
-  _rendeFrame (ctx, parentTransform, parentOpacity) {
+  rendeFrame (ctx, parentTransform, parentOpacity) {
     this.style.wrapRender(ctx, parentTransform, parentOpacity);
   }
 
@@ -216,7 +220,7 @@ export default class FlashPlayerView extends View {
 
   play (animationName, callback, loop) {
     if (!this.data) {
-      this.once(FlashPlayerView.LOADED, () => {
+      this.once(MovieClip.LOADED, () => {
         this.play(animationName, callback, loop)
       });
       return;
@@ -303,9 +307,9 @@ export default class FlashPlayerView extends View {
     }
   }
 
-  addAnimationSubstitution (libraryID, newlibraryID, animationData = null, optional = false) {
+  addAnimationSubstitution (libraryID, replacementLibraryID, animationData = null, optional = false) {
     var library = animationData ? animationData.library : this._library;
-    var replacement = library[newlibraryID];
+    var replacement = library[replacementLibraryID];
     if (!optional || replacement) {
       this._substitutes[libraryID] = replacement;
       this.clearBoundsMap();
@@ -333,6 +337,49 @@ export default class FlashPlayerView extends View {
     this.clearBoundsMap();
   }
 
+  // WIP: retrocompatibility with old skinning system
+  // setSkinForChild (animationID, skinID) {
+  //   if (this.loaded) {
+  //     if (this._currentSkin !== skinID) {
+  //       var skins = this.data.skins;
+  //       for (var skinElementID in skins) {
+  //         var skin = skins[skinElementID];
+  //         var libraryID = skin.default.id;
+  //         if (skin[skinID]) {
+  //           var skinData = skin[skinID];
+  //           var replacementLibraryID = skinData.id;
+  //           var symbol = this._library[replacementLibraryID];
+  //           var transform = skinData.transform;
+
+  //           // applying all skin transforms
+  //           var timeline = symbol.timeline;
+  //           for (var f = 0; f < timeline.length; f += 1) {
+  //             var children = timeline[f];
+  //             for (var c = 0; c < children.length; c += 1) {
+  //               var child = children[c];
+  //               console.error('   * before', child.transform)
+  //               child.transform = child.transform.clone().transform(transform);
+  //               console.error('   * after', child.transform)
+  //             }
+  //           }
+
+  //           console.error(replacementLibraryID, symbol, transform)
+  //           this.addAnimationSubstitution(libraryID, replacementLibraryID);
+  //         }
+  //       }
+  //       this._currentSkin = skinID;
+  //     }
+
+  //     // libraryID = skins[libraryID].default;
+  //     // var replacementLibraryID = skins[libraryID][skinID];
+  //     // this.addAnimationSubstitution(libraryID, replacementLibraryID);
+  //   } else {
+  //     this.once(MovieClip.LOADED, () => {
+  //       this.setSkinForChild(libraryID, skinID);
+  //     })
+  //   }
+  // }
+
   setData (data) {
     if (this.data === data) { return; }
 
@@ -340,7 +387,7 @@ export default class FlashPlayerView extends View {
       this.data = data;
       this.fps = this._opts.fps || this.data.frameRate || 30;
       this._library = data.library;
-      this.emit(FlashPlayerView.LOADED);
+      this.emit(MovieClip.LOADED);
     } else {
       this.data = null;
       this.animation = null;
@@ -414,4 +461,4 @@ function returnCanvasToPool (canvas) {
   canvasPool.push(canvas);
 }
 
-FlashPlayerView.LOADED = 'loaded';
+MovieClip.LOADED = 'loaded';

--- a/src/movieclip/Viewer.js
+++ b/src/movieclip/Viewer.js
@@ -1,0 +1,204 @@
+import device from 'device';
+import DataSource from 'squill/models/DataSource';
+import ListView from 'ui/ListView';
+import CellView from 'ui/CellView';
+import ScrollView from 'ui/ScrollView';
+import TextView from 'ui/TextView';
+import View from 'ui/View';
+import MovieClip from './MovieClip';
+
+var DESIGN_WIDTH = 1536;
+var BUTTON_WIDTH = 400;
+var BUTTON_HEIGHT = 30;
+var PADDING = 20;
+
+class ListCell extends CellView {
+
+  constructor (opts) {
+    super(opts);
+
+    this.label = new TextView({
+      superview: this,
+      y: 1,
+      padding: 10,
+      width: BUTTON_WIDTH,
+      height: BUTTON_HEIGHT - 1,
+      color: '#ffffff',
+      size: 20,
+      autoFontSize: false
+    });
+  }
+
+  setData (data) {
+    super.setData(data);
+    this.label.style.backgroundColor = data.type === 'skin' ? '#999900' : '#003300';
+    this.label.setText(data.name);
+  }
+
+}
+
+export default class Viewer extends View {
+
+  constructor (opts) {
+    super(opts);
+
+    this.scaleView = new View({
+      superview: this,
+      width: this.style.width,
+      height: this.style.height
+    });
+
+    this.viewport = new View({
+      superview: this.scaleView,
+      backgroundColor: '#330000',
+      x: BUTTON_WIDTH + PADDING,
+      y: PADDING,
+      width: DESIGN_WIDTH - BUTTON_WIDTH - PADDING * 2,
+      height: this.style.height
+    });
+
+    this.cross = new View({ superview: this.viewport });
+
+    this.crossVert = new View({
+      superview: this.cross,
+      x: -1,
+      y: -20,
+      width: 2,
+      height: 40,
+      backgroundColor: '#00ff00'
+    });
+
+    this.crossHorz = new View({
+      superview: this.cross,
+      x: -20,
+      y: -1,
+      width: 40,
+      height: 2,
+      backgroundColor: '#00ff00'
+    });
+
+    this.animBounds = new View({
+      superview: this.viewport,
+      backgroundColor: '#ffffff',
+      opacity: 0.1
+    });
+
+    this.mc = new MovieClip({
+      superview: this.viewport,
+      x: this.viewport.style.width * 0.5,
+      y: this.viewport.style.height * 0.5,
+      url: opts && opts.url || ''
+    });
+
+    this.dataSource = new DataSource({ key: 'name' });
+
+    this.dataSource.setSorter(function (obj) {
+      return (obj.type === 'skin' ? 'a' : 'b') + obj.name;
+    });
+
+    this.buttonList = new ListView({
+      superview: this.scaleView,
+      width: BUTTON_WIDTH,
+      height: 200,
+      scrollX: false,
+      dataSource: this.dataSource,
+      selectable: 'single',
+      getCell: () => {
+        return new ListCell({
+          superview: this.buttonList,
+          width: BUTTON_WIDTH,
+          height: BUTTON_HEIGHT
+        });
+      }
+    });
+
+    this.buttonList.model.subscribe('Select', this, this.onButtonClick);
+
+    this.reflow();
+
+    if (this.mc.loaded) {
+      this.onMovieClipLoaded();
+    } else {
+      this.mc.once(MovieClip.LOADED, () => this.onMovieClipLoaded());
+    }
+  }
+
+  onMovieClipLoaded() {
+    this.animationIndex = -1;
+    this.animationCount = this.mc.animationList.length;
+
+    var data = [];
+
+    var mcSkinData = this.mc.data.skins;
+    var skinMap = {};
+    var sortIndex = 0;
+    for (var anim in mcSkinData) {
+      for (var skinName in mcSkinData[anim]) {
+        if (!skinMap[skinName]) {
+          skinMap[skinName] = true;
+          data.push({
+            type: 'skin',
+            name: skinName
+          });
+        }
+      }
+    }
+
+    var animList = this.mc.animationList;
+
+    for (var i = 0; i < animList.length; i++) {
+      data.push({
+        type: 'animation',
+        name: animList[i]
+      });
+    }
+
+    this.dataSource.add(data);
+
+    this.mc.loop(this.mc.animationList[0]);
+  }
+
+  updateOpts (opts) {
+    super.updateOpts(opts);
+    if (opts && opts.url && this.mc) {
+      this.mc.url = opts.url;
+    }
+  }
+
+  onButtonClick (data) {
+    var name = data.name;
+    if (data.type === 'skin') {
+      for (var i = 0; i < this.mc.animationList.length; i++) {
+        this.mc.setSkinForChild(this.mc.animationList[i], name);
+      }
+    } else {
+      this.mc.loop(name);
+    }
+    this.updateMCPosition();
+  }
+
+  reflow () {
+    var s = this.scaleView.style;
+    s.scale = this.style.width / DESIGN_WIDTH;
+    var height = this.style.height / s.scale;
+    s.height = this.buttonList.style.height = height;
+
+    this.viewport.style.height = height - PADDING * 2;
+    this.updateMCPosition();
+    this.mc.style.x = this.cross.style.x = this.viewport.style.width * 0.5;
+    this.mc.style.y = this.cross.style.y = this.viewport.style.height * 0.5;
+    this.scaleView.style.width = this.style.width;
+    this.scaleView.style.height = this.style.height;
+  }
+
+  updateMCPosition () {
+    var bounds = this.mc.getBounds();
+    this.animBounds.updateOpts({
+      x: this.viewport.style.width * 0.5 + bounds.x,
+      y: this.viewport.style.height * 0.5 + bounds.y,
+      width: bounds.width,
+      height: bounds.height
+    });
+  }
+
+}

--- a/src/platforms/browser/webgl/Matrix2D.js
+++ b/src/platforms/browser/webgl/Matrix2D.js
@@ -3,7 +3,7 @@ let exports = {};
 var sin = Math.sin;
 var cos = Math.cos;
 
-class Matrix2D {
+export default class Matrix2D {
   constructor () {
     this.identity();
   }
@@ -119,7 +119,4 @@ class Matrix2D {
 }
 
 var helperMatrix = new Matrix2D();
-
-exports = Matrix2D;
-
-export default exports;
+Matrix2D.ELEMENT_COUNT = 6;

--- a/src/platforms/browser/webgl/Matrix2D.js
+++ b/src/platforms/browser/webgl/Matrix2D.js
@@ -119,4 +119,3 @@ export default class Matrix2D {
 }
 
 var helperMatrix = new Matrix2D();
-Matrix2D.ELEMENT_COUNT = 6;

--- a/src/platforms/browser/webgl/WebGLContext2D.js
+++ b/src/platforms/browser/webgl/WebGLContext2D.js
@@ -621,6 +621,10 @@ class Context2D {
     this.stack.state.transform.setTo(a, b, c, d, tx, ty);
   }
 
+  getTransform () {
+    return this.stack.state.transform;
+  }
+
   transform (a, b, c, d, tx, ty) {
     this._helperTransform.setTo(a, b, c, d, tx, ty);
     this.stack.state.transform.transform(this._helperTransform);

--- a/src/ui/ListView.js
+++ b/src/ui/ListView.js
@@ -42,7 +42,7 @@ var FORWARD_KEYS = {
 /**
  * @extends ui.ScrollView
  */
-exports = class extends ScrollView {
+export default class ListView extends ScrollView {
   constructor (opts) {
     opts.scrollBounds = {
       minX: 0,
@@ -235,14 +235,14 @@ exports = class extends ScrollView {
     }
   }
   render (ctx) {
-    var viewportChanged = super.render(ctx);
+    super.render(ctx);
 
-    if (viewportChanged || this._needsModelRender || this.model._needsSort) {
+    if (this._viewportChanged || this._needsModelRender || this.model._needsSort) {
       this._needsModelRender = false;
       this.model.render(this.getCurrentViewport());
     }
+    this.popViewport();
   }
 };
 
-exports.prototype.tag = 'ListView';
-export default exports;
+ListView.prototype.tag = 'ListView';

--- a/src/ui/backend/ReflowManager.js
+++ b/src/ui/backend/ReflowManager.js
@@ -128,8 +128,6 @@ exports = class {
       view._layout.reflow();
     }
 
-    view.reflow();
-
     // always reflow children if a layout changes sizes
     if (view._layout) {
       var style = view.style;

--- a/src/ui/backend/ReflowManager.js
+++ b/src/ui/backend/ReflowManager.js
@@ -128,6 +128,8 @@ exports = class {
       view._layout.reflow();
     }
 
+    view.reflow();
+
     // always reflow children if a layout changes sizes
     if (view._layout) {
       var style = view.style;

--- a/src/ui/backend/canvas/ViewBacking.js
+++ b/src/ui/backend/canvas/ViewBacking.js
@@ -61,6 +61,7 @@ export default class ViewBacking extends BaseBacking {
     this._hasTick = !!view._tick;
     this._hasRender = !!view._render;
     this._subviewsWithTicks = null;
+    this._usesSeparateViewport = false;
 
     this._addedAt = 0;
   }
@@ -315,6 +316,10 @@ export default class ViewBacking extends BaseBacking {
     var subviews = this._visibleSubviews;
     for (var i = 0; i < subviews.length; i++) {
       subviews[i].wrapRender(ctx, gt, globalAlpha);
+    }
+
+    if (this._usesSeparateViewport) {
+      this._view.popViewport();
     }
 
     ctx.clearFilter();

--- a/src/ui/backend/canvas/ViewBacking.js
+++ b/src/ui/backend/canvas/ViewBacking.js
@@ -310,7 +310,7 @@ export default class ViewBacking extends BaseBacking {
     }
 
     if (this._hasRender) {
-      this._view._render(ctx);
+      this._view._render(ctx, gt);
     }
     
     var subviews = this._visibleSubviews;

--- a/src/ui/resource/Image.js
+++ b/src/ui/resource/Image.js
@@ -99,7 +99,7 @@ var Canvas = device.get('Canvas');
 var _imgDataCanvas = null;
 var _imgDataCtx = null;
 
-exports = class extends PubSub {
+export default class ImageWrapper extends PubSub {
   constructor (opts) {
     super();
 
@@ -447,24 +447,23 @@ exports = class extends PubSub {
 
 };
 
-exports.__clearCache__ = function () {
+ImageWrapper.__clearCache__ = function () {
   ImageCache = {};
 };
 
-exports.prototype.getSource = exports.prototype.getSrcImg;
-exports.prototype.setSource = exports.prototype.setSrcImg;
+ImageWrapper.prototype.getSource = ImageWrapper.prototype.getSrcImg;
+ImageWrapper.prototype.setSource = ImageWrapper.prototype.setSrcImg;
 
-exports.prototype.getSourceWidth = exports.prototype.getSourceW;
-exports.prototype.getSourceHeight = exports.prototype.getSourceH;
-exports.prototype.getOrigWidth = exports.prototype.getOrigW;
-exports.prototype.getOrigHeight = exports.prototype.getOrigH;
+ImageWrapper.prototype.getSourceWidth = ImageWrapper.prototype.getSourceW;
+ImageWrapper.prototype.getSourceHeight = ImageWrapper.prototype.getSourceH;
+ImageWrapper.prototype.getOrigWidth = ImageWrapper.prototype.getOrigW;
+ImageWrapper.prototype.getOrigHeight = ImageWrapper.prototype.getOrigH;
 
-exports.prototype.setSourceWidth = exports.prototype.setSourceW;
-exports.prototype.setSourceHeight = exports.prototype.setSourceH;
+ImageWrapper.prototype.setSourceWidth = ImageWrapper.prototype.setSourceW;
+ImageWrapper.prototype.setSourceHeight = ImageWrapper.prototype.setSourceH;
 
-exports.prototype.getMap = exports.prototype.getBounds;
-exports.prototype.setMap = exports.prototype.setBounds;
+ImageWrapper.prototype.getMap = ImageWrapper.prototype.getBounds;
+ImageWrapper.prototype.setMap = ImageWrapper.prototype.setBounds;
 
-exports.prototype.isLoaded = exports.prototype.isReady;
+ImageWrapper.prototype.isLoaded = ImageWrapper.prototype.isReady;
 
-export default exports;


### PR DESCRIPTION
## Why
- The `MovieClip` was an externalized component that is used across all games. Being highly dependent on timestep's rendering system, keeping it separated made it difficult to add changes to timestep without impacting the stability of the `MovieClip`.

- The `Movieclip` component contained a duplicate component from timestep (`Matrix2D`).

- Observed performances were not as good as they could be.

- One bug was also identified concerning the buffering of animations when its substitutions changed.

- Some concepts were absent such as `Symbol`, `Instance, `Graphic` and `library`. Also the term `MovieClip` is misleading as it will conflict with a [MovieClip symbol](https://www.thoughtco.com/g00/flash-graphics-and-movie-clips-140549?i10c.referrer=https%3A%2F%2Fwww.google.co.jp%2F) of an animation (that is not supported yet).

## How


## Results
When it comes to the `MovieClip` component itself, it corresponds to a major boost (around 50% on the new skinning system). Therefore that is no surprise that Cats receives a good performance improvement >10%. It appears to be a minor improvement on Everwing though: ~1% in gameplay and 5% on the landing screen.

### Engine tick
The ticking of the engine appears ~15% faster on Everwing's landing screen:
Before
<img width="269" alt="screen shot 2017-06-16 at 6 49 11 pm" src="https://user-images.githubusercontent.com/1897225/27271581-81b786f2-5500-11e7-9e2a-723400cab7d0.png">

After
<img width="271" alt="screen shot 2017-06-26 at 8 22 56 pm" src="https://user-images.githubusercontent.com/1897225/27575246-18c1160e-5b54-11e7-9ffc-d3ea304c202b.png">


### Chrome profile (macbook)
#### On Cats
Before
<img width="393" alt="screen shot 2017-06-27 at 3 45 00 pm" src="https://user-images.githubusercontent.com/1897225/27575311-485bc68e-5b54-11e7-8e15-55d5fe1ce9b2.png">

After
<img width="396" alt="screen shot 2017-06-27 at 3 36 49 pm" src="https://user-images.githubusercontent.com/1897225/27575310-4856d0b6-5b54-11e7-8d3f-c3304f0305bf.png">

The time taken by the `renderFrame` method is roughly half what it used to be!
Other performance improvements we can see on this profile comparison are due to all the optimizations that were done so far in timestep. We can notice that the time taken by the `wrapRender` method (which includes all the rendering pipeline) has been divided by 2.

#### On Everwing
Profiling on the landing page gives roughly 5% improvement:
Before
<img width="416" alt="screen shot 2017-06-17 at 2 37 54 pm" src="https://user-images.githubusercontent.com/1897225/27578063-e6b68c3e-5b5d-11e7-9613-da138a942c94.png">

After
<img width="398" alt="screen shot 2017-06-27 at 5 27 46 pm" src="https://user-images.githubusercontent.com/1897225/27578290-a6d2b704-5b5e-11e7-970b-b52a9899ae6d.png">
For some reason the performance improvement of the `renderFrame` method is not as good as in Cats. The `MovieClip` component used in Everwing is older and might have been more efficient in the past.


**Notes on follow-up work:**
- There is some commented code that would correspond to the support of Flash MovieClip and Graphic options as well as identifications consistent with Flash (an instance can have a `libraryID`, a `className` and optionally an `InstanceName`). If Implemented we would be one step closer to full Flash feature support (there is a long way to go). 
- There are 2 ways to make the animations run slightly faster. By using the proper `className` identification system in order to determine which animations can be substituted and by optimizing the animation hierarchy but it would imply reexporting all the animations.