### PR TITLE
Hot fix to movieclip

### DIFF
--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -161,7 +161,7 @@ export default class MovieClip extends View {
         this.updateCanvasBounds(bounds);
         this._ctx.clear();
         this._transform.setTo(1, 0, 0, 1, -bounds.x, -bounds.y);
-        this.animation._wrapRender(this._ctx, this._transform, 1, this._instance, this._substitutes /*, deltaFrame */);
+        this.animation._wrapRender(this._ctx, this._transform, 1, this._instance, this._substitutes, this.framesElapsed);
         this._frameDirty = false;
       }
 
@@ -169,7 +169,7 @@ export default class MovieClip extends View {
     } else {
       // Render directly to context
       this._transform.copy(transform);
-      this.animation._wrapRender(ctx, this._transform, ctx.globalAlpha, this._instance, this._substitutes /*, deltaFrame */);
+      this.animation._wrapRender(ctx, this._transform, ctx.globalAlpha, this._instance, this._substitutes, this.framesElapsed);
     }
   }
 
@@ -218,7 +218,7 @@ export default class MovieClip extends View {
     var timeline = animation.timeline;
     for (var frame = 0; frame < timeline.length; frame++) {
       this._instance.frame = frame;
-      animation.expandBoundingBox(this._bbox, transform, this._instance, this._substitutes);
+      animation.expandBoundingBox(this._bbox, transform, this._instance, this._substitutes, 1);
     }
 
     this._instance.frame = actualFrame;

--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -49,8 +49,6 @@ class BBox {
 
 }
 
-var Instance = AnimationData.Instance;
-
 const Canvas = device.get('Canvas');
 const canvasPool = [];
 
@@ -78,7 +76,6 @@ export default class MovieClip extends View {
     this.frameCount = 0;
     this.isPlaying = false;
     this._animationName = '';
-    this._instance = new Instance('', 0, IDENTITY_MATRIX, 1);
 
     this._callback = null;
     this._boundsMap = {};
@@ -148,8 +145,6 @@ export default class MovieClip extends View {
       return;
     }
 
-    this._instance.frame = this.frame;
-
     if (this._buffered && this._nbViewSubstitutions === 0) {
       // Update and render internal canvas to context
       var bounds = this.getBounds();
@@ -161,7 +156,7 @@ export default class MovieClip extends View {
         this.updateCanvasBounds(bounds);
         this._ctx.clear();
         this._transform.setTo(1, 0, 0, 1, -bounds.x, -bounds.y);
-        this.animation._wrapRender(this._ctx, this._transform, 1, this._instance, this._substitutes, this.framesElapsed);
+        this.animation._wrapRender(this._ctx, this._transform, 1, this.frame, this.framesElapsed, this._substitutes);
         this._frameDirty = false;
       }
 
@@ -169,15 +164,11 @@ export default class MovieClip extends View {
     } else {
       // Render directly to context
       this._transform.copy(transform);
-      this.animation._wrapRender(ctx, this._transform, ctx.globalAlpha, this._instance, this._substitutes, this.framesElapsed);
+      this.animation._wrapRender(ctx, this._transform, ctx.globalAlpha, this.frame, this.framesElapsed, this._substitutes);
     }
   }
 
   getBounds (elementID) {
-    if (!this.loaded) {
-      return NULL_BOUNDS;
-    }
-
     if (!elementID) {
       var animationBounds = this._boundsMap[this._animationName];
       if (animationBounds) {
@@ -188,21 +179,17 @@ export default class MovieClip extends View {
     }
 
     var animation = this._substitutes[elementID] || this._library[elementID];
-    if (!animation || animation.animation === null) {
-      return NULL_BOUNDS;
-    }
-
-    var bounds = new Rect(0, 0, Infinity, Infinity);
-    if (elementID === this._animationName) {
-      this._boundsMap[this._animationName] = bounds;
-    }
-
     this.updateBoundingBox(animation, IDENTITY_MATRIX);
 
+    var bounds = new Rect(0, 0, Infinity, Infinity);
     bounds.x = Math.floor(this._bbox.left);
     bounds.y = Math.floor(this._bbox.top);
     bounds.width = Math.ceil(this._bbox.right - this._bbox.left);
     bounds.height = Math.ceil(this._bbox.bottom - this._bbox.top);
+
+    if (elementID === this._animationName) {
+      this._boundsMap[this._animationName] = bounds;
+    }
 
     // TODO: bounds with negative dimensions should be compatible with timestep engine
     if (bounds.width === -Infinity) { bounds.width = 0; }
@@ -211,29 +198,60 @@ export default class MovieClip extends View {
     return bounds;
   }
 
+  getCurrentBounds (elementID) {
+    var animation = this.animation;
+    if (elementID) {
+      animation = this._substitutes[elementID] || this._library[elementID];
+    }
+
+    this.updateCurrentBoundingBox(animation);
+
+    var bounds = new Rect(
+      Math.floor(this._bbox.left),
+      Math.floor(this._bbox.top),
+      Math.ceil(this._bbox.right - this._bbox.left),
+      Math.ceil(this._bbox.bottom - this._bbox.top)
+    );
+
+    if (bounds.width === -Infinity) { bounds.width = 0; }
+    if (bounds.height === -Infinity) { bounds.height = 0; }
+
+    return bounds;
+  }
+
   updateBoundingBox (animation, transform) {
     this._bbox.reset();
+    if (!animation || !animation.timeline) {
+      return;
+    }
 
     var actualFrame = this.frame;
     var timeline = animation.timeline;
     for (var frame = 0; frame < timeline.length; frame++) {
-      this._instance.frame = frame;
-      animation.expandBoundingBox(this._bbox, transform, this._instance, this._substitutes, 1);
+      animation.expandBoundingBox(this._bbox, transform, frame, frame, this._substitutes);
     }
-
-    this._instance.frame = actualFrame;
   }
 
-  expandBoundingBox (boundingBox, transform, child, substitutes) {
-    if (!this.animation) {
-      return;
+  expandBoundingBox (boundingBox, transform, frame, framesElapsed, substitutes, currentBounds) {
+    if (currentBounds) {
+      this.updateCurrentBoundingBox(this.animation);
+    } else {
+      this.updateBoundingBox(this.animation, transform);
     }
 
-    this.updateBoundingBox(this.animation, transform);
     boundingBox.left = Math.min(this._bbox.left, boundingBox.left);
     boundingBox.top = Math.min(this._bbox.top, boundingBox.top);
     boundingBox.right = Math.max(this._bbox.right, boundingBox.right);
     boundingBox.bottom = Math.max(this._bbox.bottom, boundingBox.left);
+  }
+
+  updateCurrentBoundingBox (animation) {
+    this._bbox.reset();
+    if (!animation) {
+      return;
+    }
+
+    animation.expandBoundingBox(this._bbox, IDENTITY_MATRIX, this.frame, this.framesElapsed, this._substitutes, true);
   }
 
   clearBoundsMap () {
@@ -250,8 +268,6 @@ export default class MovieClip extends View {
 
     this._frameDirty = animationName !== this._animationName;
     this._animationName = animationName;
-    this._instance.libraryID = animationName;
-    this._instance.frame = 0;
     this.looping = loop || false;
     this.isPlaying = true;
     this.animation = this._library[animationName];


### PR DESCRIPTION
At the moment the export format does not specify which instances are ```MovieClips``` and ```Graphics``` so we have to use a hack to consider any substituted animation as a ```MovieClip```.

Also added a method to get the current bounds of the animation (much more efficient that computing the overall bounds of the animation).