### PR TITLE
Exposing an empty symbol on MovieClip

### DIFF
--- a/src/movieclip/AnimationData.js
+++ b/src/movieclip/AnimationData.js
@@ -358,4 +358,5 @@ class Instance {
 
 }
 
-AnimationData.Instance = Instance;
+var emptyTimeline = [[]];
+AnimationData.EMPTY_SYMBOL = new Symbol(emptyTimeline);

--- a/src/movieclip/MovieClip.js
+++ b/src/movieclip/MovieClip.js
@@ -473,3 +473,5 @@ MovieClip.LOADED = 'loaded';
 
 MovieClip.getAnimation = AnimationData.getAnimation;
 MovieClip.loadAnimation = AnimationData.loadFromURL;
+
+MovieClip.EMPTY_SYMBOL = AnimationData.EMPTY_SYMBOL;


### PR DESCRIPTION
Exposed an empty symbol to allow for substitution of MovieClip elements with an empty symbol.