### PR TITLE
ScrollView fixes

### DIFF
--- a/src/ui/ScrollView.js
+++ b/src/ui/ScrollView.js
@@ -314,10 +314,10 @@ export default class ScrollView extends View {
     var s = this._contentView.style;
     var padding = this.style.padding || {};
 
-    bounds.minX = s.x;
-    bounds.maxX = s.x + s.width + (padding.right || 0);
-    bounds.minY = s.y;
-    bounds.maxY = s.y + s.height + (padding.bottom || 0);
+    bounds.minX = 0;
+    bounds.maxX = s.width + (padding.right || 0);
+    bounds.minY = 0;
+    bounds.maxY = s.height + (padding.bottom || 0);
   }
   buildView () {
     this._snapPixels = this._opts.snapPixels || 1 / this.getPosition().scale;

--- a/src/ui/layout/BoxLayout.js
+++ b/src/ui/layout/BoxLayout.js
@@ -71,7 +71,6 @@ export default class BoxLayout {
     }
   }
   _onSubviewAdded (view, subview) {
-    subview.style.addResizeListeners();
     view.connectEvent(subview, 'resize', bind(view, 'needsReflow'));
   }
   _onSubviewRemoved (view, subview) {


### PR DESCRIPTION
`BoxLayout.js`: There's no such function. Apparently there was one in pre-es6 version (https://github.com/gameclosure/timestep/blob/master/src/ui/layout/BackingExtension.js#L167) - probably someone forgot to remove the reference.

`ScrollView.js`: I took a look at EverWing code and it looks like there's no use of auto-sizing anywhere, so this problem slipped under the radar. Basically, every time ScrollView's content was updated, the bounds were calculated incorrectly.